### PR TITLE
Proper fix for memory leak

### DIFF
--- a/helm/applications/posix-mapper/CHANGELOG.md
+++ b/helm/applications/posix-mapper/CHANGELOG.md
@@ -1,4 +1,8 @@
-# CHANGELOG for POSIX Mapper (0.3.0)
+# CHANGELOG for POSIX Mapper (0.4.0)
+
+## 2025.02.11 (0.4.0)
+- Rework fix of memory leak by properly closing the Hibernate SessionFactory
+- Removed default `hostPath` in storage spec of postgresql database
 
 ## 2025.01.24 (0.3.0)
 - Fix memory leak in POSIX Mapper application

--- a/helm/applications/posix-mapper/Chart.yaml
+++ b/helm/applications/posix-mapper/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/applications/posix-mapper/Chart.yaml
+++ b/helm/applications/posix-mapper/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.0"
+appVersion: "0.3.1"

--- a/helm/applications/posix-mapper/values.yaml
+++ b/helm/applications/posix-mapper/values.yaml
@@ -22,7 +22,7 @@ skaha:
 deployment:
   hostname: example.org    # Change this!
   posixMapper:
-    image: images.opencadc.org/platform/posix-mapper:0.3.0
+    image: images.opencadc.org/platform/posix-mapper:0.3.1
     imagePullPolicy: Always
     resourceID: ivo://opencadc.org/posix-mapper
 
@@ -107,5 +107,3 @@ postgresql:
     schema: mapping
   storage:
     spec:
-      hostPath:
-        path: "/posix-mapper/data"


### PR DESCRIPTION
Removed default `hostPath` storage spec for PostgreSQL database.