### PR TITLE
feat(monitoring): add ServiceMonitor for kueue metrics

### DIFF
--- a/configs/kueue/dev/servicemonitor.yaml
+++ b/configs/kueue/dev/servicemonitor.yaml
@@ -1,0 +1,28 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/instance: kueue
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kueue
+    argocd.argoproj.io/instance: kueue
+    control-plane: controller-manager
+  name: kueue-controller-manager-metrics-service
+  namespace: kueue-system
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      path: /metrics
+      port: https
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
+        serverName: kueue-controller-manager-metrics-service.kueue-system.svc
+  namespaceSelector:
+    matchNames:
+      - kueue-system
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: kueue
+      app.kubernetes.io/name: kueue
+      control-plane: controller-manager

--- a/configs/kueue/dev/servicemonitor.yaml
+++ b/configs/kueue/dev/servicemonitor.yaml
@@ -8,7 +8,6 @@ metadata:
     argocd.argoproj.io/instance: kueue
     control-plane: controller-manager
   name: kueue-controller-manager-metrics-service
-  namespace: kueue-system
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token


### PR DESCRIPTION
This PR includes a servicemonitor configuration that can be used while we wait for Kueue to update their configuration. (I will open up an Issue and PR shortly)

