### PR TITLE
fix: use staged images to avoid docker io repository rate limits

### DIFF
--- a/helm/applications/cavern/Chart.yaml
+++ b/helm/applications/cavern/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.1
+version: 0.6.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/applications/cavern/templates/postgres-deploy.yaml
+++ b/helm/applications/cavern/templates/postgres-deploy.yaml
@@ -22,7 +22,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: postgres
-          image: postgres:15
+          image: images.opencadc.org/platform/dependencies/postgres:15.12
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 5432  # Exposes container port

--- a/helm/applications/posix-mapper/Chart.yaml
+++ b/helm/applications/posix-mapper/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/applications/posix-mapper/templates/postgres-deploy.yaml
+++ b/helm/applications/posix-mapper/templates/postgres-deploy.yaml
@@ -20,7 +20,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: postgres
-          image: postgres:13
+          image: images.opencadc.org/platform/dependencies/postgres:13.20
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 5432  # Exposes container port

--- a/helm/applications/skaha/Chart.yaml
+++ b/helm/applications/skaha/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.4
+version: 0.11.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/applications/skaha/templates/_helpers.tpl
+++ b/helm/applications/skaha/templates/_helpers.tpl
@@ -85,7 +85,7 @@ The init containers for the launch scripts.
             drop:
               - ALL
       - name: init-users-groups
-        image: redis:7-alpine
+        image: images.opencadc.org/platform/dependencies/redis:7.4.2-alpine3.21
         command: ["/init-users-groups/init-users-groups.sh"]
         env:
         - name: HOME

--- a/helm/applications/skaha/templates/skaha-tomcat-deployment.yaml
+++ b/helm/applications/skaha/templates/skaha-tomcat-deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       initContainers:
       - name: init-skaha-service
-        image: busybox
+        image: images.opencadc.org/platform/dependencies/busybox:1.37.0
         imagePullPolicy: IfNotPresent
         command: ['sh', '-c', 'mkdir -p ${SKAHA_TLD}/home && mkdir -p ${SKAHA_TLD}/projects']  # Expected to have /arc mounted
         volumeMounts:

--- a/helm/applications/skaha/templates/tests/test-connection.yaml
+++ b/helm/applications/skaha/templates/tests/test-connection.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: busybox
+      image: images.opencadc.org/platform/dependencies/busybox:1.37.0
       command: ['wget']
       args: ['{{ include "skaha.fullname" . }}:8080']
   restartPolicy: Never


### PR DESCRIPTION
# Description
Certain colleagues cannot access the docker.io host to obtain public images.  Until a proper solution can be found, we'll host the images on the CADC Harbor instance.

# Changes
- Add public images to `images.opencadc.org/platform/dependencies` namespace for quick access to identify them and remove later if needed
  - `postgres:15.12`
  - `postgres:13.20`
  - `redis:7.4.2-alpine3.21`
  - `busybox:1.37.0`  // still used for skaha to initialize `/home` and `/projects` folders if Cavern not deployed