### PR TITLE
SP-5254 - Science Platform compatibility with PV/PVCs to link data to the user's area

### DIFF
--- a/helm/applications/skaha/init-users-datasets-symlink-config/init-users-datasets-symlink.sh
+++ b/helm/applications/skaha/init-users-datasets-symlink-config/init-users-datasets-symlink.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-if [ -z "$USER_DATASETS_ROOT_PATH" ]; then
-  echo "USER_DATASETS_ROOT_PATH is not set."
-  exit 1
-fi
-
 if [ -d "$USER_DATASETS_ROOT_PATH" ]; then
   for DATASET in $(find "$USER_DATASETS_ROOT_PATH" -maxdepth 1); do
     ln -sf "$DATASET" "$HOME"

--- a/helm/applications/skaha/init-users-datasets-symlink-config/init-users-datasets-symlink.sh
+++ b/helm/applications/skaha/init-users-datasets-symlink-config/init-users-datasets-symlink.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ -d "/datasets" ]; then
+  for DATASET in $(find /datasets -maxdepth 1); do
+    ln -sf "$DATASET" "$HOME"
+  done
+  rm "$HOME/datasets"
+else
+  echo "/datasets directory does not exist."
+fi

--- a/helm/applications/skaha/init-users-datasets-symlink-config/init-users-datasets-symlink.sh
+++ b/helm/applications/skaha/init-users-datasets-symlink-config/init-users-datasets-symlink.sh
@@ -1,10 +1,15 @@
 #!/bin/sh
 
-if [ -d "/datasets" ]; then
-  for DATASET in $(find /datasets -maxdepth 1); do
+if [ -z "$USER_DATASETS_ROOT_PATH" ]; then
+  echo "USER_DATASETS_ROOT_PATH is not set."
+  exit 1
+fi
+
+if [ -d "$USER_DATASETS_ROOT_PATH" ]; then
+  for DATASET in $(find "$USER_DATASETS_ROOT_PATH" -maxdepth 1); do
     ln -sf "$DATASET" "$HOME"
   done
-  rm "$HOME/datasets"
+  rm "$HOME/$(basename "$USER_DATASETS_ROOT_PATH")"
 else
-  echo "/datasets directory does not exist."
+  echo "$USER_DATASETS_ROOT_PATH directory does not exist."
 fi

--- a/helm/applications/skaha/skaha-config/launch-carta.yaml
+++ b/helm/applications/skaha/skaha-config/launch-carta.yaml
@@ -84,6 +84,7 @@ spec:
         - mountPath: "/etc/group"
           name: etc-group
           subPath: group
+${user.runtime.volumemounts}
         {{ template "skaha.session.commonVolumeMounts" . }}
       {{- with .Values.deployment.skaha.sessions.tolerations }}
       tolerations:
@@ -102,4 +103,9 @@ spec:
         configMap:
           name: init-users-groups-config
           defaultMode: 0777
+      - name: init-users-datasets-symlink
+        configMap:
+          name: init-users-datasets-symlink-config
+          defaultMode: 0777
+${user.runtime.volumes}
       {{ template "skaha.session.commonVolumes" . }}

--- a/helm/applications/skaha/skaha-config/launch-desktop.yaml
+++ b/helm/applications/skaha/skaha-config/launch-desktop.yaml
@@ -90,6 +90,7 @@ spec:
           name: templates
         - mountPath: "/skaha-system"
           name: start-desktop
+${user.runtime.volumemounts}
         {{ template "skaha.session.commonVolumeMounts" . }}
       {{- with .Values.deployment.skaha.sessions.tolerations }}
       tolerations:
@@ -112,4 +113,9 @@ spec:
         configMap:
           name: init-users-groups-config
           defaultMode: 0777
+      - name: init-users-datasets-symlink
+        configMap:
+          name: init-users-datasets-symlink-config
+          defaultMode: 0777
+${user.runtime.volumes}
       {{ template "skaha.session.commonVolumes" . }}

--- a/helm/applications/skaha/skaha-config/launch-notebook.yaml
+++ b/helm/applications/skaha/skaha-config/launch-notebook.yaml
@@ -130,5 +130,5 @@ ${user.runtime.volumemounts}
         configMap:
           name: init-users-datasets-symlink-config
           defaultMode: 0777
-  ${user.runtime.volumes}
+${user.runtime.volumes}
       {{ template "skaha.session.commonVolumes" . }}

--- a/helm/applications/skaha/skaha-config/launch-notebook.yaml
+++ b/helm/applications/skaha/skaha-config/launch-notebook.yaml
@@ -101,6 +101,7 @@ spec:
           subPath: group
         - mountPath: "/skaha-system"
           name: start-jupyterlab
+${user.runtime.volumemounts}
         {{ template "skaha.session.commonVolumeMounts" . }}
         securityContext:
           privileged: false
@@ -125,4 +126,9 @@ spec:
         configMap:
           name: init-users-groups-config
           defaultMode: 0777
+      - name: init-users-datasets-symlink
+        configMap:
+          name: init-users-datasets-symlink-config
+          defaultMode: 0777
+  ${user.runtime.volumes}
       {{ template "skaha.session.commonVolumes" . }}

--- a/helm/applications/skaha/templates/_helpers.tpl
+++ b/helm/applications/skaha/templates/_helpers.tpl
@@ -112,6 +112,8 @@ The init containers for the launch scripts.
         env:
         - name: HOME
           value: "${SKAHA_TLD}/home/${skaha.userid}"
+        - name: USER_DATASETS_ROOT_PATH
+          value: "{{ .Values.deployment.skaha.sessions.prepareData.userDatasetsRootPath | default "/datasets" }}"
         volumeMounts:
         - mountPath: "/init-users-datasets-symlink"
           name: init-users-datasets-symlink

--- a/helm/applications/skaha/templates/_helpers.tpl
+++ b/helm/applications/skaha/templates/_helpers.tpl
@@ -105,6 +105,19 @@ The init containers for the launch scripts.
           capabilities:
             drop:
               - ALL
+      - name: init-users-datasets-symlink
+        image: alpine:latest
+        command: ["/init-users-datasets-symlink/init-users-datasets-symlink.sh"]
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: HOME
+          value: "${SKAHA_TLD}/home/${skaha.userid}"
+        volumeMounts:
+        - mountPath: "/init-users-datasets-symlink"
+          name: init-users-datasets-symlink
+        - mountPath: "${SKAHA_TLD}"
+          name: cavern-volume
+          subPath: "cavern"
 {{- with .Values.deployment.extraHosts }}
       hostAliases:
 {{- range $extraHost := . }}

--- a/helm/applications/skaha/templates/init-users-datasets-symlink-configmap.yaml
+++ b/helm/applications/skaha/templates/init-users-datasets-symlink-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: init-users-datasets-symlink-config
+  namespace: {{ .Values.skahaWorkload.namespace }}
+data:
+  {{- (.Files.Glob "init-users-datasets-symlink-config/*").AsConfig | nindent 2 }}

--- a/helm/applications/skaha/templates/skaha-tomcat-deployment.yaml
+++ b/helm/applications/skaha/templates/skaha-tomcat-deployment.yaml
@@ -48,6 +48,10 @@ spec:
           value: "{{ .Values.deployment.skaha.skahaTld }}"
         - name: GPU_ENABLED
           value: "{{ .Values.deployment.skaha.sessions.gpuEnabled | default "false" }}"
+        - name: USER_DATASETS_ROOT_PATH
+          value: "{{ .Values.deployment.skaha.sessions.userDatasetsRootPath | default "/datasets" }}"
+        - name: PREPARE_DATA_ENABLED
+          value: "{{ .Values.deployment.skaha.sessions.prepareDataEnabled | default "false" }}"
         - name: skaha.homedir
           value: "{{ .Values.deployment.skaha.skahaTld }}/home"
         - name: skaha.namespace

--- a/helm/applications/skaha/templates/skaha-tomcat-deployment.yaml
+++ b/helm/applications/skaha/templates/skaha-tomcat-deployment.yaml
@@ -49,9 +49,9 @@ spec:
         - name: GPU_ENABLED
           value: "{{ .Values.deployment.skaha.sessions.gpuEnabled | default "false" }}"
         - name: USER_DATASETS_ROOT_PATH
-          value: "{{ .Values.deployment.skaha.sessions.userDatasetsRootPath | default "/datasets" }}"
+          value: "{{ .Values.deployment.skaha.sessions.prepareData.userDatasetsRootPath | default "/datasets" }}"
         - name: PREPARE_DATA_ENABLED
-          value: "{{ .Values.deployment.skaha.sessions.prepareDataEnabled | default "false" }}"
+          value: "{{ .Values.deployment.skaha.sessions.prepareData.enabled | default "false" }}"
         - name: skaha.homedir
           value: "{{ .Values.deployment.skaha.skahaTld }}/home"
         - name: skaha.namespace

--- a/helm/applications/skaha/values.yaml
+++ b/helm/applications/skaha/values.yaml
@@ -90,6 +90,11 @@ deployment:
       minEphemeralStorage: "20Gi"   # The initial requested amount of ephemeral (local) storage.  Does NOT apply to Desktop sessions.
       maxEphemeralStorage: "200Gi"  # The maximum amount of ephemeral (local) storage to allow a Session to extend to.  Does NOT apply to Desktop sessions.
 
+      # This is where the user datasets are stored. The path to the datasets directory.
+      userDatasetsRootPath: "/datasets"
+      # Is prepare-data enabled?
+      prepareDataEnabled: "false"
+
       # Optionally configure the initContainer image for Redis.  Useful for those not able to reach docker.io
       # Defaults to redis-7.4.2-alpine3.21.
       # Example:

--- a/helm/applications/skaha/values.yaml
+++ b/helm/applications/skaha/values.yaml
@@ -90,10 +90,12 @@ deployment:
       minEphemeralStorage: "20Gi"   # The initial requested amount of ephemeral (local) storage.  Does NOT apply to Desktop sessions.
       maxEphemeralStorage: "200Gi"  # The maximum amount of ephemeral (local) storage to allow a Session to extend to.  Does NOT apply to Desktop sessions.
 
-      # This is where the user datasets are stored. The path to the datasets directory.
-      userDatasetsRootPath: "/datasets"
-      # Is prepare-data enabled?
-      prepareDataEnabled: "false"
+      prepareData:
+        # Is prepare-data enabled?
+        enabled: "false"
+        # This is where the user datasets are stored. The path to the datasets directory.
+        userDatasetsRootPath: "/datasets"
+        
 
       # Optionally configure the initContainer image for Redis.  Useful for those not able to reach docker.io
       # Defaults to redis-7.4.2-alpine3.21.


### PR DESCRIPTION
The changes made as part of this PR: 

1. Added the file to create symlink for `/datasets` 
2. Added runtime volume mounts for pvc in launch config 
3. Added flag `PREPARE_DATA_ENABLED` to toggle prepare data. 
