### PR TITLE
Carta 5 beta

### DIFF
--- a/helm/applications/skaha/launch-scripts/skaha-carta.sh
+++ b/helm/applications/skaha/launch-scripts/skaha-carta.sh
@@ -15,7 +15,7 @@ fi
 ROOT=$1
 FOLDER=$2
 URL_PREFIX=$3
-COMMAND="carta --no_browser --top_level_folder=${ROOT} --idle_timeout=100000 --debug_no_auth --http_url_prefix=${URL_PREFIX} ${FOLDER}"
+COMMAND="carta --no_browser --top_level_folder=${ROOT} --port=6901 --idle_timeout=100000 --debug_no_auth --http_url_prefix=${URL_PREFIX} ${FOLDER}"
 echo "root: $ROOT"
 echo "folder: $FOLDER"
 echo "url_prefix: $URL_PREFIX"

--- a/helm/applications/skaha/launch-scripts/skaha-carta.sh
+++ b/helm/applications/skaha/launch-scripts/skaha-carta.sh
@@ -7,15 +7,21 @@ SELF=skaha-carta
 TS=$(date)
 echo "$TS $SELF START"
 
-if [ "$#" -ne 2 ]; then
-    echo "Usage: skaha-carta <root> <folder>"
+if [ "$#" -ne 3 ]; then
+    echo "Usage: skaha-carta <root> <folder> <session url>"
     exit 2
 fi
 
 ROOT=$1
 FOLDER=$2
+URL_PREFIX=$3
+COMMAND="carta --no_browser --top_level_folder=${ROOT} --idle_timeout=100000 --debug_no_auth --http_url_prefix=${URL_PREFIX} ${FOLDER}"
 echo "root: $ROOT"
 echo "folder: $FOLDER"
-echo "command: carta --no_browser --top_level_folder=$ROOT --port=6901 --idle_timeout=100000 --debug_no_auth $FOLDER"
-carta --no_browser --top_level_folder=$ROOT --port=6901 --idle_timeout=100000 --debug_no_auth $FOLDER
+echo "url_prefix: $URL_PREFIX"
+echo "command: ${COMMAND}"
+echo "Add --verbosity=5 to the command for more output"
+echo ""
+eval "${COMMAND}"
+
 # A bit over a day timeout. Disable token authentication.

--- a/helm/applications/skaha/skaha-config/ingress-carta.yaml
+++ b/helm/applications/skaha/skaha-config/ingress-carta.yaml
@@ -19,7 +19,7 @@ spec:
     - websecure
   routes:
   - kind: Rule
-    match: Host(`${skaha.sessions.hostname}`) && PathPrefix(`/session/carta/http/${skaha.sessionid}`)
+    match: Host(`${skaha.sessions.hostname}`) && PathPrefix(`/session/carta/${skaha.sessionid}`)
     services:
     - kind: Service
       name: skaha-carta-svc-${skaha.sessionid}
@@ -27,10 +27,3 @@ spec:
       scheme: http
     middlewares:
       - name: workload-enable-compression
-  - kind: Rule
-    match: Host(`${skaha.sessions.hostname}`) && PathPrefix(`/session/carta/ws/${skaha.sessionid}`)
-    services:
-    - kind: Service
-      name: skaha-carta-svc-${skaha.sessionid}
-      port: 5901
-      scheme: http

--- a/helm/applications/skaha/skaha-config/ingress-carta.yaml
+++ b/helm/applications/skaha/skaha-config/ingress-carta.yaml
@@ -1,36 +1,3 @@
-apiVersion: traefik.io/v1alpha1
-kind: Middleware
-metadata:
-  name: skaha-carta-http-middleware-${skaha.sessionid}
-  ownerReferences:
-  - apiVersion: batch/v1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Job
-    name: "${skaha.jobname}"
-    uid: "${skaha.jobuid}"
-spec:
-  replacePathRegex:
-    regex: ^/session/carta/http/${skaha.sessionid}(/|$)(.*)
-    replacement: /$2
-
----
-apiVersion: traefik.io/v1alpha1
-kind: Middleware
-metadata:
-  name: skaha-carta-ws-middleware-${skaha.sessionid}
-  ownerReferences:
-  - apiVersion: batch/v1
-    blockOwnerDeletion: true
-    controller: true
-    kind: Job
-    name: "${skaha.jobname}"
-    uid: "${skaha.jobuid}"
-spec:
-  replacePathRegex:
-    regex: ^/session/carta/ws/${skaha.sessionid}(/|$)(.*)
-    replacement: /$2
-
 ---
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
@@ -43,7 +10,7 @@ metadata:
     kind: Job
     name: "${skaha.jobname}"
     uid: "${skaha.jobuid}"
-  annotations:
+  annotations: 
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
@@ -59,7 +26,7 @@ spec:
       port: 6901
       scheme: http
     middlewares:
-      - name: skaha-carta-http-middleware-${skaha.sessionid}
+      - name: workload-enable-compression
   - kind: Rule
     match: Host(`${skaha.sessions.hostname}`) && PathPrefix(`/session/carta/ws/${skaha.sessionid}`)
     services:
@@ -67,5 +34,3 @@ spec:
       name: skaha-carta-svc-${skaha.sessionid}
       port: 5901
       scheme: http
-    middlewares:
-      - name: skaha-carta-ws-middleware-${skaha.sessionid}

--- a/helm/applications/skaha/skaha-config/launch-carta.yaml
+++ b/helm/applications/skaha/skaha-config/launch-carta.yaml
@@ -57,7 +57,7 @@ spec:
         image: ${software.imageid}
         command: ["/bin/sh", "-c"]
         args:
-        - /skaha-system/skaha-carta.sh ${SKAHA_TLD} ${SKAHA_TLD}/projects
+        - /skaha-system/skaha-carta.sh ${SKAHA_TLD} ${SKAHA_TLD}/projects "${skaha.sessionurlpath}"
         imagePullPolicy: IfNotPresent
         resources:
           requests:

--- a/helm/applications/skaha/templates/skaha-middleware-compression.yaml
+++ b/helm/applications/skaha/templates/skaha-middleware-compression.yaml
@@ -1,0 +1,14 @@
+# Middleware to enable compression for Skaha sessions.  This relies on the caller setting the `accept-encoding` header in order to work.
+#
+# https://doc.traefik.io/traefik/middlewares/compress/
+#
+# Driven by a GitHub request Issue:
+# https://github.com/opencadc/science-containers/issues/123
+#
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: workload-enable-compression
+  namespace: {{ .Values.skahaWorkload.namespace }}
+spec:
+  compress: {}


### PR DESCRIPTION
# Description
Add CARTA-5 support to provide fix for long time issue affecting user interaction.  Remove unneeded port specification in command, and enable compression for Javascript.

# Changes
- Enable CARTA-5 `http_url_prefix` switch
- Remove `Middleware` objects that are no longer used
- Add Traefik Compress Middleware