### PR TITLE
feat: new portal update for storage info

### DIFF
--- a/helm/applications/science-portal/Chart.yaml
+++ b/helm/applications/science-portal/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.6.0"
+appVersion: "0.6.2"
 
 dependencies:
   - name: "redis"

--- a/helm/applications/science-portal/config/org.opencadc.science-portal.properties
+++ b/helm/applications/science-portal/config/org.opencadc.science-portal.properties
@@ -27,3 +27,5 @@ org.opencadc.science-portal.oidc.scope = {{ .scope }}
 {{- end }}
 
 org.opencadc.science-portal.tokenCache.url = redis://{{ $.Release.Name }}-redis-master.{{ $.Values.skaha.namespace }}.svc.{{ $.Values.kubernetesClusterDomain }}:6379
+
+org.opencadc.science-portal.storageXmlInfoUrl = {{ .Values.deployment.sciencePortal.storageHomeURL | required "Please set the deployment.sciencePortal.storageHomeURL to the Cavern home endpoint." }}

--- a/helm/applications/science-portal/values.yaml
+++ b/helm/applications/science-portal/values.yaml
@@ -22,7 +22,7 @@ skaha:
 deployment:
   hostname: example.host.com    # Change this!
   sciencePortal:
-    image: images.opencadc.org/platform/science-portal:0.6.0
+    image: images.opencadc.org/platform/science-portal:0.6.2
     imagePullPolicy: Always
 
     tabLabels:
@@ -57,7 +57,13 @@ deployment:
 
     # ID (URI) of the GMS Service.
     # gmsID: ivo://example.org/gms
-    gmsID: 
+    gmsID:
+
+    # Required. The absolute URL of the /home folder containing the user's home directories.  This is used to query the storage quota information.
+    # A typical value would be the /nodes/home endpoint of the Cavern service.
+    # Example:
+    #   storageHomeURL: https://example.org/cavern/nodes/home
+    storageHomeURL:
 
     # OIDC (IAM) server configuration.  These are required
     # oidc:


### PR DESCRIPTION
BREAKING CHANGE:
Science Platform configuration for `storageHomeURL` now required.