### PR TITLE
fix: version revert to remove accidentally released portal change and…

### DIFF
--- a/helm/applications/science-portal/CHANGELOG.md
+++ b/helm/applications/science-portal/CHANGELOG.md
@@ -1,4 +1,8 @@
-# CHANGELOG for Science Portal UI (Chart 0.6.0)
+# CHANGELOG for Science Portal UI (Chart 0.6.4)
+
+## 2025.06.17 (0.6.4)
+- Small fix for deploying with an existing secret for the client.
+- **EXPERIMENTAL**: Added `experimentalFeatures` to feature-flag user storage quota display.
 
 ## 2025.05.09 (0.6.0)
 - Add support for Firefly sessions

--- a/helm/applications/science-portal/Chart.lock
+++ b/helm/applications/science-portal/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: redis
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 18.19.4
+- name: utils
+  repository: file://../utils
+  version: 0.1.0
+digest: sha256:fd98d2ca0917e2d209018020b126ffd197f8dfe1a6a1a9d4c5455b5da8539cb6
+generated: "2025-06-20T09:27:13.62496174-07:00"

--- a/helm/applications/science-portal/Chart.yaml
+++ b/helm/applications/science-portal/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.1
+version: 0.6.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.6.2"
+appVersion: "0.6.0"
 
 dependencies:
   - name: "redis"

--- a/helm/applications/science-portal/config/org.opencadc.science-portal.properties
+++ b/helm/applications/science-portal/config/org.opencadc.science-portal.properties
@@ -14,7 +14,7 @@ org.opencadc.science-portal.oidc.clientID = {{ .clientID }}
 
 {{ if .existingSecretName -}}
   {{- $existingSecretName := .existingSecretName -}}
-  {{- $namespace := .Values.skaha.namespace -}}
+  {{- $namespace := $.Values.skaha.namespace -}}
   {{- $clientSecret := include "getSecretKeyValue" (list $existingSecretName "clientSecret" $namespace) -}}
 org.opencadc.science-portal.oidc.clientSecret = {{ $clientSecret }}
 {{- else -}}
@@ -28,4 +28,10 @@ org.opencadc.science-portal.oidc.scope = {{ .scope }}
 
 org.opencadc.science-portal.tokenCache.url = redis://{{ $.Release.Name }}-redis-master.{{ $.Values.skaha.namespace }}.svc.{{ $.Values.kubernetesClusterDomain }}:6379
 
-org.opencadc.science-portal.storageXmlInfoUrl = {{ .Values.deployment.sciencePortal.storageHomeURL | required "Please set the deployment.sciencePortal.storageHomeURL to the Cavern home endpoint." }}
+{{ with .Values.experimentalFeatures }}
+{{- if .enabled }}
+{{- with .storageHomeURL }}
+org.opencadc.science-portal.storageXmlInfoUrl = {{ .storageHomeURL }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/helm/applications/science-portal/values.yaml
+++ b/helm/applications/science-portal/values.yaml
@@ -22,7 +22,7 @@ skaha:
 deployment:
   hostname: example.host.com    # Change this!
   sciencePortal:
-    image: images.opencadc.org/platform/science-portal:0.6.2
+    image: images.opencadc.org/platform/science-portal:0.6.0
     imagePullPolicy: Always
 
     tabLabels:
@@ -58,12 +58,6 @@ deployment:
     # ID (URI) of the GMS Service.
     # gmsID: ivo://example.org/gms
     gmsID:
-
-    # Required. The absolute URL of the /home folder containing the user's home directories.  This is used to query the storage quota information.
-    # A typical value would be the /nodes/home endpoint of the Cavern service.
-    # Example:
-    #   storageHomeURL: https://example.org/cavern/nodes/home
-    storageHomeURL:
 
     # OIDC (IAM) server configuration.  These are required
     # oidc:
@@ -110,6 +104,14 @@ deployment:
     # Example:
     # themeName: canfar
     themeName:
+
+experimentalFeatures:
+  enabled: false
+  # Required. The absolute URL of the /home folder containing the user's home directories.  This is used to query the storage quota information.
+  # A typical value would be the /nodes/home endpoint of the Cavern service.
+  # Example:
+  #   storageHomeURL: https://example.org/cavern/nodes/home
+  # storageHomeURL:
 
 # This is a list of tolerations that will be added to the Pod spec of the Science Portal UI.
 # @see https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/


### PR DESCRIPTION
# Description
Users wanting to use the `existingSecretName` for their client secrets will encounter an error.  Also a version revert to omit a new feature that will only be released in the Summer.

# Changes
- Add experimental feature flag for future experimental features
- Add fix for client secret setting