### PR TITLE
feat: make image pull policy for user sessions configurable

### DIFF
--- a/helm/applications/skaha/Chart.yaml
+++ b/helm/applications/skaha/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.10
+version: 0.11.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/applications/skaha/README.md
+++ b/helm/applications/skaha/README.md
@@ -70,6 +70,7 @@ The following table lists the configurable parameters for the Skaha Helm chart:
 | `deployment.skaha.registryURL` | URL for the IVOA registry containing service locations | `""` |
 | `deployment.skaha.nodeAffinity` | Kubernetes Node affinity for the Skaha API Pod | `{}` |
 | `deployment.skaha.sessions.expirySeconds` | Expiry time, in seconds, for interactive sessions.  Defaults to four (4) days. | `"345600"` |
+| `deployment.skaha.sessions.imagePullPolicy` | Image pull policy for all User Sessions. | `"Always"` |
 | `deployment.skaha.sessions.maxCount` | Maximum number of interactive sessions per user.  Defaults to three (3). | `"3"` |
 | `deployment.skaha.sessions.minEphemeralStorage` | Minimum ephemeral storage, in [Kubernetes quantity](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/), for interactive sessions.  Defaults to 20Gi. | `"20Gi"` |
 | `deployment.skaha.sessions.maxEphemeralStorage` | Maximum ephemeral storage, in [Kubernetes quantity](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/), for interactive sessions.  Defaults to 200Gi. | `"200Gi"` |

--- a/helm/applications/skaha/skaha-config/launch-carta.yaml
+++ b/helm/applications/skaha/skaha-config/launch-carta.yaml
@@ -58,7 +58,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
         - /skaha-system/skaha-carta.sh ${SKAHA_TLD} ${SKAHA_TLD}/projects
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.deployment.skaha.sessions.imagePullPolicy | required "deployment.skaha.sessions.imagePullPolicy must be set." }}
         resources:
           requests:
             memory: "${software.requests.ram}"

--- a/helm/applications/skaha/skaha-config/launch-contributed.yaml
+++ b/helm/applications/skaha/skaha-config/launch-contributed.yaml
@@ -55,7 +55,7 @@ spec:
         - name: OMP_NUM_THREADS
           value: "${software.requests.cores}"
         image: ${software.imageid}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.deployment.skaha.sessions.imagePullPolicy | required "deployment.skaha.sessions.imagePullPolicy must be set." }}
         resources:
           requests:
             memory: "${software.requests.ram}"

--- a/helm/applications/skaha/skaha-config/launch-desktop-app.yaml
+++ b/helm/applications/skaha/skaha-config/launch-desktop-app.yaml
@@ -62,7 +62,7 @@ spec:
               - ALL
         image: "${software.imageid}"
         workingDir: "${SKAHA_TLD}/home/${skaha.userid}"
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.deployment.skaha.sessions.imagePullPolicy | required "deployment.skaha.sessions.imagePullPolicy must be set." }}
         resources:
           requests:
             memory: "${software.requests.ram}"

--- a/helm/applications/skaha/skaha-config/launch-desktop.yaml
+++ b/helm/applications/skaha/skaha-config/launch-desktop.yaml
@@ -62,7 +62,7 @@ spec:
             drop:
               - ALL
         image: ${software.imageid}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.deployment.skaha.sessions.imagePullPolicy | required "deployment.skaha.sessions.imagePullPolicy must be set." }}
         resources:
           requests:
             memory: "1Gi"

--- a/helm/applications/skaha/skaha-config/launch-firefly.yaml
+++ b/helm/applications/skaha/skaha-config/launch-firefly.yaml
@@ -82,7 +82,7 @@ spec:
               }
             }
         image: ${software.imageid}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.deployment.skaha.sessions.imagePullPolicy | required "deployment.skaha.sessions.imagePullPolicy must be set." }}
         resources:
           # https://docs.cloudbees.com/docs/cloudbees-ci-kb/latest/best-practices/jvm-memory-settings-best-practice
           # memory limits / requests are equal and use -XX:InitialRAMPercentage / -XX:MaxRAMPercentage

--- a/helm/applications/skaha/skaha-config/launch-headless.yaml
+++ b/helm/applications/skaha/skaha-config/launch-headless.yaml
@@ -57,7 +57,7 @@ spec:
             drop:
               - ALL
         workingDir: "${SKAHA_TLD}/home/${skaha.userid}"
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.deployment.skaha.sessions.imagePullPolicy | required "deployment.skaha.sessions.imagePullPolicy must be set." }}
         resources:
           requests:
             memory: "${software.requests.ram}"

--- a/helm/applications/skaha/skaha-config/launch-notebook.yaml
+++ b/helm/applications/skaha/skaha-config/launch-notebook.yaml
@@ -77,7 +77,7 @@ spec:
         command: ["/skaha-system/start-jupyterlab.sh"]
         args:
         - ${skaha.sessionid}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.deployment.skaha.sessions.imagePullPolicy | required "deployment.skaha.sessions.imagePullPolicy must be set." }}
         resources:
           requests:
             memory: "${software.requests.ram}"

--- a/helm/applications/skaha/values.yaml
+++ b/helm/applications/skaha/values.yaml
@@ -90,6 +90,12 @@ deployment:
       minEphemeralStorage: "20Gi"   # The initial requested amount of ephemeral (local) storage.  Does NOT apply to Desktop sessions.
       maxEphemeralStorage: "200Gi"  # The maximum amount of ephemeral (local) storage to allow a Session to extend to.  Does NOT apply to Desktop sessions.
 
+      # The image pull policy for User Sessions (applies to ALL types).  This is the default, but can be overridden.  Deafults to Always.
+      # @see https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+      # Example:
+      #   imagePullPolicy: IfNotPresent
+      imagePullPolicy: Always 
+
       # Optionally configure the initContainer image for Redis.  Useful for those not able to reach docker.io
       # Defaults to redis-7.4.2-alpine3.21.
       # Example:


### PR DESCRIPTION
# Description
The `imagePullPolicy` for User Session images is hard-coded to `IfNotPresent`.  Should a user override the existing image, it will not be recognized on Nodes that already contain the image.  We will allow deployers the option of setting `Always`, for example.

# Changes
- Chart version bump
- Create new configuration `deployment.skaha.sessions.imagePullPolicy`.
- Default to `Always`.