### PR TITLE
feat: add tls yaml support for configuration of user session ingress

### DIFF
--- a/helm/applications/cavern/templates/cavern-tomcat-deployment.yaml
+++ b/helm/applications/cavern/templates/cavern-tomcat-deployment.yaml
@@ -64,13 +64,13 @@ spec:
             path: {{ printf "%s/%s" .Values.deployment.cavern.endpoint "availability" }}
             port: {{ $containerPort }}
           initialDelaySeconds: 15
-          periodSeconds: 10
+          periodSeconds: 300
         livenessProbe:
           httpGet:
             path: {{ printf "%s/%s" .Values.deployment.cavern.endpoint "availability" }}
             port: {{ $containerPort }}
           initialDelaySeconds: 25
-          periodSeconds: 20
+          periodSeconds: 300
 {{- with .Values.deployment.extraHosts }}
       hostAliases:
 {{- range $extraHost := . }}

--- a/helm/applications/skaha/CHANGELOG.md
+++ b/helm/applications/skaha/CHANGELOG.md
@@ -1,4 +1,7 @@
-# CHANGELOG for Skaha User Session API (Chart 0.11.12)
+# CHANGELOG for Skaha User Session API (Chart 0.11.13)
+
+## 2025.07.10 (0.11.13)
+- Feature: Add support for TLS in User Sessions IngressRoute.
 
 ## 2025.07.09 (0.11.12)
 - Fix: Remove unnecessary missing label messager from image caching script.

--- a/helm/applications/skaha/Chart.yaml
+++ b/helm/applications/skaha/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.12
+version: 0.11.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/applications/skaha/README.md
+++ b/helm/applications/skaha/README.md
@@ -80,6 +80,7 @@ The following table lists the configurable parameters for the Skaha Helm chart:
 | `deployment.skaha.sessions.queue.<typename>.queueName` | Name of the `LocalQueue` instance from Kueue for the given type | `""` |
 | `deployment.skaha.sessions.queue.<typename>.priorityClass` | Name of the `priorityClass` for the given type to allow some pre-emption | `""` |
 | `deployment.skaha.sessions.hostname` | Hostname to access user sessions on.  Defaults to `deployment.hostname` | `deployment.hostname` |
+| `deployment.skaha.sessions.tls` | TLS configuration for the User Sessions IngressRoute. | `{}` |
 | `deployment.skaha.sessions.extraVolumes` | List of extra `volume` and `volumeMount` to be mounted in User Sessions.  See the `values.yaml` file for examples. | `[]` |
 | `deployment.skaha.sessions.gpuEnabled` | Enable GPU support for User Sessions.  Defaults to `false` | `false` |
 | `deployment.skaha.sessions.nodeAffinity` | Kubernetes Node affinity for the Skaha User Session Pods | `{}` |

--- a/helm/applications/skaha/skaha-config/ingress-carta.yaml
+++ b/helm/applications/skaha/skaha-config/ingress-carta.yaml
@@ -43,10 +43,11 @@ metadata:
     kind: Job
     name: "${skaha.jobname}"
     uid: "${skaha.jobuid}"
-  annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
-    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
+  tls:
+  {{- with .Values.deployment.skaha.sessions.tls }}
+    {{- toYaml . | nindent 6 }}
+  {{- end }}
   entryPoints:
     - web
     - websecure

--- a/helm/applications/skaha/skaha-config/ingress-contributed.yaml
+++ b/helm/applications/skaha/skaha-config/ingress-contributed.yaml
@@ -26,10 +26,11 @@ metadata:
     kind: Job
     name: "${skaha.jobname}"
     uid: "${skaha.jobuid}"
-  annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
-    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
+  tls:
+  {{- with .Values.deployment.skaha.sessions.tls }}
+    {{- toYaml . | nindent 6 }}
+  {{- end }}
   entryPoints:
     - web
     - websecure

--- a/helm/applications/skaha/skaha-config/ingress-desktop.yaml
+++ b/helm/applications/skaha/skaha-config/ingress-desktop.yaml
@@ -26,10 +26,11 @@ metadata:
     kind: Job
     name: "${skaha.jobname}"
     uid: "${skaha.jobuid}"
-  annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
-    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
+  tls:
+  {{- with .Values.deployment.skaha.sessions.tls }}
+    {{- toYaml . | nindent 6 }}
+  {{- end }}
   entryPoints:
     - web
     - websecure

--- a/helm/applications/skaha/skaha-config/ingress-firefly.yaml
+++ b/helm/applications/skaha/skaha-config/ingress-firefly.yaml
@@ -10,10 +10,11 @@ metadata:
     kind: Job
     name: "${skaha.jobname}"
     uid: "${skaha.jobuid}"
-  annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
-    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
+  tls:
+  {{- with .Values.deployment.skaha.sessions.tls }}
+    {{- toYaml . | nindent 6 }}
+  {{- end }}
   entryPoints:
     - web
     - websecure

--- a/helm/applications/skaha/skaha-config/ingress-notebook.yaml
+++ b/helm/applications/skaha/skaha-config/ingress-notebook.yaml
@@ -9,10 +9,11 @@ metadata:
     kind: Job
     name: "${skaha.jobname}"
     uid: "${skaha.jobuid}"
-  annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
-    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
+  tls:
+  {{- with .Values.deployment.skaha.sessions.tls }}
+    {{- toYaml . | nindent 6 }}
+  {{- end }}
   entryPoints:
     - web
     - websecure

--- a/helm/applications/skaha/templates/skaha-config-configmap.yaml
+++ b/helm/applications/skaha/templates/skaha-config-configmap.yaml
@@ -6,7 +6,18 @@ metadata:
   namespace: {{ .Values.skaha.namespace }}
 data:
 {{ tpl ($.Files.Glob "config/*").AsConfig . | indent 2 }}
-{{ range $path, $_ :=  $.Files.Glob "skaha-config/*.yaml" }}
+
+# Treat IngressRoute configuration as a Helm Template.
+# This is allowed to be able to specify TLS specification in the IngressRoute.
+# jenkinsd 2025.07.15
+#
+{{ tpl ($.Files.Glob "skaha-config/ingress*.yaml").AsConfig . | indent 2 }}
+
+{{ range $path, $_ :=  $.Files.Glob "skaha-config/launch*.yaml" }}
+  {{ base $path }}: |
+  {{- tpl ($.Files.Get $path) $currContext | nindent 4 }}
+{{ end }}
+{{ range $path, $_ :=  $.Files.Glob "skaha-config/service*.yaml" }}
   {{ base $path }}: |
   {{- tpl ($.Files.Get $path) $currContext | nindent 4 }}
 {{ end }}

--- a/helm/applications/skaha/values.yaml
+++ b/helm/applications/skaha/values.yaml
@@ -153,6 +153,13 @@ deployment:
       #   hostname: myhost.example.org
       # hostname:
 
+      # Optionally set the TLS configiuration that contains the certificate information for the alternate hostname for User Sessions.  This will go into the Traefik IngressRoute spec.
+      # @see https://doc.traefik.io/traefik/v2.3/routing/providers/kubernetes-crd/#kind-ingressroute
+      # Example:
+      #   tls:
+      #     secretName: myhost-tls-secret
+      tls: {}
+
       # Declare extra volume mounts in User Sessions.  The "type: parameter in volume section is constant.
       # extraVolumes:
       # - name: example-pvc-name


### PR DESCRIPTION
# Description

Current TLS input for `IngressRoute` objects that route to User Sessions is missing SSL termination information in the CANFAR deployment of the Science Platform `skaha` service.  Allow configuration of the User Session TLS if needed.

# Changes
- Remove old annotations from `IngressRoute` objects
- Add optional configuration for `tls` information to conform to 2.3 spec (https://doc.traefik.io/traefik/v2.3/routing/providers/kubernetes-crd/#kind-ingressroute)
- Loosen the Cavern probes to help with startup and reduce errors.