### PR TITLE
feat: support admin api keys for seamless trusted admin access mainly…

### DIFF
--- a/helm/applications/cavern/CHANGELOG.md
+++ b/helm/applications/cavern/CHANGELOG.md
@@ -1,4 +1,7 @@
-# CHANGELOG for Cavern User Storage (Chart 0.6.7)
+# CHANGELOG for Cavern User Storage (Chart 0.7.0)
+
+## 2025.09.09 (0.7.0)
+- Feature: Support `admin-api-key` (`.deployment.cavern.adminAPIKeys`) for trusted admin access.
 
 ## 2025.08.21 (0.6.7)
 - Fix: Wee regression with the JWSK feature.

--- a/helm/applications/cavern/Chart.yaml
+++ b/helm/applications/cavern/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.7
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.8.5"
+appVersion: "0.9.0"
 
 dependencies:
   - name: "utils"

--- a/helm/applications/cavern/README.md
+++ b/helm/applications/cavern/README.md
@@ -58,3 +58,81 @@ $ curl https://myhost.example.com/cavern/availability
   <!--<clientip>192.1.1.4</clientip>-->
 </vosi:availability>
 ```
+
+## Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `kubernetesClusterDomain` | Kubernetes cluster domain used to find internal hosts | `cluster.local` |
+| `replicaCount` | Number of Cavern replicas to deploy | `1` |
+| `tolerations` | Array of tolerations to pass to Kubernetes for fine-grained Node targeting of the Cavern API | `[]` |
+| `deployment.hostname` | Hostname for the Cavern deployment | `""` |
+| `deployment.cavern.loggingGroups` | List of groups permitted to adjust logging levels for the Cavern service. | `[]` |
+| `deployment.cavern.image` | Cavern Docker image | `images.opencadc.org/platform/cavern:<current release version>` |
+| `deployment.cavern.imagePullPolicy` | Image pull policy for the Cavern container | `IfNotPresent` |
+| `deployment.cavern.resourceID` | Resource ID (URI) for this Cavern service | `""` |
+| `deployment.cavern.oidcURI` | URI (or URL) for the OIDC service | `""` |
+| `deployment.cavern.gmsID` | Resource ID (URI) for the IVOA Group Management Service | `""` |
+| `deployment.cavern.adminAPIKeys` | API keys for client applications that can create new allocations | `{}` |
+| `deployment.cavern.allocations.defaultSizeGB` | Default size of user allocations in GB | `10` |
+| `deployment.cavern.allocations.parentFolders` | List of parent folders to create for user allocations.  Best to leave this alone. | `["/home", "/projects"]` |
+| `deployment.cavern.filesystem.dataDir` | Persistent data directory in the Cavern container | `""` |
+| `deployment.cavern.filesystem.subPath` | Relative path to the node/file content that could be mounted in other containers | `""` |
+| `deployment.cavern.filesystem.rootOwner.username` | Username of the root owner of the filesystem data (parent of allocations) directory | `""` |
+| `deployment.cavern.filesystem.rootOwner.uid` | UID of the root owner of the filesystem data (parent of allocations) directory | `""` |
+| `deployment.cavern.filesystem.rootOwner.gid` | GID of the root owner of the filesystem data (parent of allocations) directory | `""` |
+| `deployment.cavern.filesystem.rootOwner.adminUsername` | Admin username for the filesystem data (parent of allocations) directory
+| `deployment.cavern.identityManagerClass` | Class name for the identity manager used by Cavern | `org.opencadc.auth.StandardIdentityManager` |
+| `deployment.cavern.uws.db.install` | Whether to deploy a local PostgreSQL database for UWS | `true` |
+| `deployment.cavern.uws.db.image` | PostgreSQL image to use for UWS | `postgres:15.12` |
+| `deployment.cavern.uws.db.runUID` | UID for the PostgreSQL user in the UWS database | `999` |
+| `deployment.cavern.uws.db.database` | Name of the UWS database | `uws` |
+| `deployment.cavern.uws.db.url` | JDBC URL for the UWS database.  Use instead of `database`. | `jdbc:postgresql://cavern-uws-db:5432/uws` |
+| `deployment.cavern.uws.db.username` | Username for the UWS database | `uwsuser` |
+| `deployment.cavern.uws.db.password` | Password for the UWS database | `uwspwd` |
+| `deployment.cavern.uws.db.schema` | Schema name for the UWS database | `uws` |
+| `deployment.cavern.uws.db.maxActive` | Maximum number of active connections to the UWS database | `2` |
+| `deployment.applicationName` | Optional rename of the application from the default "cavern" | `cavern` |
+| `deployment.endpoint` | Endpoint to serve the Cavern service from | `/cavern` |
+| `deployment.extraEnv` | Extra environment variables to set in the Cavern container | `[]` |
+| `deployment.extraVolumeMounts` | Extra volume mounts for the Cavern container | `[]` |
+| `deployment.extraVolumes` | Extra volumes to mount in the Cavern container | `[]` |
+| `deployment.resources.requests.memory` | Memory request for the Cavern container | `1Gi` |
+| `deployment.resources.requests.cpu` | CPU request for the Cavern container | `500m` |
+| `deployment.resources.limits.memory` | Memory limit for the Cavern container | `1Gi` |
+| `deployment.resources.limits.cpu` | CPU limit for the Cavern container | `500m` |
+| `tolerations` | Tolerations to apply to the Cavern Pod | `[]` |
+| `secrets` | Secrets to create for the Cavern service, such as CA certificates | `{}` |
+| `service.cavern.extraPorts` | Extra ports to expose for the Cavern service | `[]` |
+| `storage.service.spec` | Storage specification for the Cavern service | `{}` |
+
+## User Allocations with special access
+Cavern typically accepts user allocation requests from the Administrative user, but it can be configured to allow other users to request allocations as well. This is done by adding the user's API key to the `deployment.cavern.allocations.apiKeys` configuration:
+```yaml
+deployment:
+  cavern:
+    adminAPIKeys:
+      skaha: "skahasecretkey1234567890"
+      prepareData: "preparedatasecretkey1234567890"
+```
+
+With this configuration, listed clients can request new user allocations using the `api-key` challenge type in the `Authorization` header.  This `api-key` represents a trusted client application to act on behalf of the Administrative user:
+```sh
+$ curl -Lv --header "Authorization: api-key prepareData:preparedatasecretkey1234567890" --header "content-type: text/xml" --upload-file user-alloc-upload-jwt.xml https://example.org/cavern/nodes/home/new-user
+```
+
+Where the upload XML file would look like this:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<vos:node xmlns:vos="http://www.ivoa.net/xml/VOSpace/v2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          uri="vos://exmaple.org~cavern/home/new-user" xsi:type="vos:ContainerNode">
+  <vos:properties>
+    <vos:property uri="ivo://opencadc.org/vospace/core#creatorJWT">JWT_TOKEN_REPLACE_ME</vos:property> <!-- JWT token of the new user -->
+    <vos:property uri="ivo://cadc.nrc.ca/vospace/core#inheritPermissions">true</vos:property>
+    <vos:property uri="ivo://ivoa.net/vospace/core#quota">524288000</vos:property>. <!-- 500MB quota example, adjust as needed -->
+  </vos:properties>
+  <vos:nodes />
+</vos:node>
+```
+Where `JWT_TOKEN_REPLACE_ME` is replaced with a valid JWT token of the new user (i.e. the one making the request to be added).  Don't forget to set the `vos:property:uri` to the correct value for your service and the path of the new user.

--- a/helm/applications/cavern/config/cavern.properties
+++ b/helm/applications/cavern/config/cavern.properties
@@ -9,9 +9,22 @@ org.opencadc.cavern.filesystem.subPath = {{ .Values.deployment.cavern.filesystem
 
 org.opencadc.cavern.nodes.QuotaPlugin = {{ .Values.deployment.cavern.quotaPlugin }}
 
+{{ $allocations := required ".Values.deployment.cavern.allocations is required." .Values.deployment.cavern.allocations }}
+
+{{- with $allocations }}
+org.opencadc.cavern.defaultQuotaGB = {{ .defaultSizeGB | required "defaultSizeGB is required in .Values.deployment.cavern.allocations.defaultSizeGB" }}
+
+{{ $parentFolders := required "at least one parent folder is required in .Values.deployment.cavern.allocations.parentFolders.  Don't modify this unless you're absolutely sure!" .parentFolders }}
+{{ range $parentFolders }}
 # Required folders.  This will check for the existence of them, and create if necessary.
-org.opencadc.cavern.allocationParent = /home
-org.opencadc.cavern.allocationParent = /projects
+org.opencadc.cavern.allocationParent = {{ . }}
+{{- end }}
+{{- end }}
+
+# (optional) API Keys with administrative privileges to create User Allocations.
+{{- range $clientName, $apiKey := .Values.deployment.cavern.adminAPIKeys }}
+org.opencadc.cavern.adminAPIKey = {{ printf "%s:%s" $clientName $apiKey }}
+{{- end }}
 
 {{- with .Values.deployment.cavern.filesystem.rootOwner }}
 # owner of root node has admin power

--- a/helm/applications/cavern/values.yaml
+++ b/helm/applications/cavern/values.yaml
@@ -11,7 +11,7 @@ skaha:
 deployment:
   hostname: example.org
   cavern:
-    image: images.opencadc.org/platform/cavern:0.8.5
+    image: images.opencadc.org/platform/cavern:0.9.0
     imagePullPolicy: IfNotPresent
 
     # How cavern identifies itself.
@@ -45,6 +45,25 @@ deployment:
     #
     # quotaPlugin: {NoQuotaPlugin | CephFSQuotaPlug}
 
+    # User Allocation settings.  This is used to create new folders under the main root allocation folders, namely /home and /projects.
+    allocations:
+      # Required.  The default size, in GB, of an allocation.  This is used in the absence of the Quota VOSpace property.  Can be a floating point number.
+      # Provided value is 10 (10 GiB) by default.
+      # Example:
+      #   defaultSizeGB: 25.5
+      defaultSizeGB: 10
+
+      # The parent folders that will be used to create new allocations.  This is a list of folders that will be created if they do not exist.
+      # It's best to keep these as /home and /projects, but you can change them if you wish.  There may be implications!
+      # Example:
+      #   parentFolders:
+      #     - "/home"
+      #     - "/projects"
+      #     - "/data"
+      parentFolders:
+        - "/home"
+        - "/projects"
+
     # The /home and /projects folders will be automatically created if not present.
     filesystem:
       # persistent data directory in container
@@ -61,6 +80,15 @@ deployment:
         username: ""
         uid:
         gid:
+
+    # The API keys object that will be permitted to perform administrative tasks.  These will be passed as authorization headers to the Cavern API.
+    # The token values will be used by client applications, and each client matching a clientApplicationName should be configured with the matching token.
+    # Format is <clientApplicationName>: <apiKeyToken>
+    # Example:
+    #   adminAPIKeys:
+    #     skaha: "token-value"
+    #     prepareData: "another-token-value"
+    adminAPIKeys: {}
 
       # (optional) base directory exposed for sshfs mounts
       # sshfs:


### PR DESCRIPTION
… for allocations

# Changes
- Add support for `admin-api-key` with configurations for allowed clients
- Add support to set the `ivo://opencadc.org/vospace/core#creatorJWT` property to set user allocations using the `admin-api-key`
- Default quota support added