### PR TITLE
fix: make probes configurable

### DIFF
--- a/helm/applications/cavern/CHANGELOG.md
+++ b/helm/applications/cavern/CHANGELOG.md
@@ -1,4 +1,7 @@
-# CHANGELOG for Cavern User Storage (Chart 0.7.0)
+# CHANGELOG for Cavern User Storage (Chart 0.7.1)
+
+## 2025.09.22 (0.7.1)
+- Make liveness and readiness probes configurable.
 
 ## 2025.09.09 (0.7.0)
 - Feature: Support `admin-api-key` (`.deployment.cavern.adminAPIKeys`) for trusted admin access.

--- a/helm/applications/cavern/Chart.yaml
+++ b/helm/applications/cavern/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/applications/cavern/README.md
+++ b/helm/applications/cavern/README.md
@@ -101,6 +101,8 @@ $ curl https://myhost.example.com/cavern/availability
 | `deployment.resources.requests.cpu` | CPU request for the Cavern container | `500m` |
 | `deployment.resources.limits.memory` | Memory limit for the Cavern container | `1Gi` |
 | `deployment.resources.limits.cpu` | CPU limit for the Cavern container | `500m` |
+| `livenessProbe` | Configure the liveness probe check | `{}` |
+| `readinessProbe` | Configure the readiness probe check | `{}` |
 | `tolerations` | Tolerations to apply to the Cavern Pod | `[]` |
 | `secrets` | Secrets to create for the Cavern service, such as CA certificates | `{}` |
 | `service.cavern.extraPorts` | Extra ports to expose for the Cavern service | `[]` |

--- a/helm/applications/cavern/templates/cavern-tomcat-deployment.yaml
+++ b/helm/applications/cavern/templates/cavern-tomcat-deployment.yaml
@@ -59,18 +59,14 @@ spec:
         {{- with .Values.deployment.cavern.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        readinessProbe:
-          httpGet:
-            path: {{ printf "%s/%s" .Values.deployment.cavern.endpoint "availability" }}
-            port: {{ $containerPort }}
-          initialDelaySeconds: 15
-          periodSeconds: 300
+        {{- with .Values.livenessProbe }}
         livenessProbe:
-          httpGet:
-            path: {{ printf "%s/%s" .Values.deployment.cavern.endpoint "availability" }}
-            port: {{ $containerPort }}
-          initialDelaySeconds: 25
-          periodSeconds: 300
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.readinessProbe }}
+        readinessProbe:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
 {{- with .Values.deployment.extraHosts }}
       hostAliases:
 {{- range $extraHost := . }}

--- a/helm/applications/cavern/values.yaml
+++ b/helm/applications/cavern/values.yaml
@@ -164,6 +164,23 @@ deployment:
 # 
 tolerations: []
 
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+# Example:
+#   livenessProbe:
+#     httpGet:
+#       path: /cavern/availability
+#       port: 8080
+#     initialDelaySeconds: 60
+livenessProbe: {}
+
+# Example:
+#   readinessProbe:
+#     httpGet:
+#       path: /cavern/availability
+#       port: 8080
+#     initialDelaySeconds: 30
+readinessProbe: {}
+
 secrets:
   # Uncomment to enable local or self-signed CA certificates for your domain to be trusted.
   # cavern-cacert-secret:


### PR DESCRIPTION
# Description
The `livenessProbe` and `readinessProbe` stanzas are hard-coded, but should be configurable to work with slow deployments.

# Changes
- Allow for setting the probe values