### PR TITLE
CADC-15119: Configure autoscaling for Skaha backend

### DIFF
--- a/helm/applications/skaha/README.md
+++ b/helm/applications/skaha/README.md
@@ -20,63 +20,63 @@ A Helm chart to install the Skaha web service of the CANFAR Science Platform
 | autoscaling.enabled | bool | `true` | Enable HorizontalPodAutoscaler for skaha-tomcat. Target and scaling behavior are intentionally chart-managed (CPU 65%). |
 | autoscaling.maxReplicas | int | `6` | Maximum number of skaha-tomcat replicas. |
 | autoscaling.minReplicas | int | `2` | Minimum number of skaha-tomcat replicas. |
-| deployment.hostname | string | `"myhost.example.com"` |  |
-| deployment.skaha.apiVersion | string | `"v1"` |  |
-| deployment.skaha.defaultQuotaGB | string | `"10"` |  |
-| deployment.skaha.identityManagerClass | string | `"org.opencadc.auth.StandardIdentityManager"` |  |
-| deployment.skaha.image | string | `"images.opencadc.org/platform/skaha:1.2.1"` |  |
-| deployment.skaha.imageCache.refreshSchedule | string | `"*/30 * * * *"` |  |
-| deployment.skaha.imagePullPolicy | string | `"Always"` |  |
-| deployment.skaha.init.image | string | `"busybox:1.37.0"` |  |
-| deployment.skaha.init.imagePullPolicy | string | `"IfNotPresent"` |  |
-| deployment.skaha.posixMapperCacheTTLSeconds | string | `"86400"` |  |
-| deployment.skaha.priorityClassName | string | `"uber-user-preempt-high"` |  |
-| deployment.skaha.registryHosts | string | `"images.canfar.net"` |  |
-| deployment.skaha.resources.limits.cpu | string | `"2000m"` |  |
-| deployment.skaha.resources.limits.memory | string | `"3Gi"` |  |
-| deployment.skaha.resources.requests.cpu | string | `"1000m"` |  |
-| deployment.skaha.resources.requests.memory | string | `"2Gi"` |  |
-| deployment.skaha.serviceAccountName | string | `"skaha"` |  |
-| deployment.skaha.sessions.expirySeconds | string | `"345600"` |  |
-| deployment.skaha.sessions.flexResourceRequests.headless.cpuCores | string | `"1"` |  |
-| deployment.skaha.sessions.flexResourceRequests.headless.memoryInGB | string | `"4"` |  |
-| deployment.skaha.sessions.imagePullPolicy | string | `"Always"` |  |
-| deployment.skaha.sessions.ingress.customResponseHeaders | object | `{}` |  |
-| deployment.skaha.sessions.ingress.tls | object | `{}` |  |
-| deployment.skaha.sessions.initContainerImage | string | `"redis:8.2.2-bookworm"` |  |
-| deployment.skaha.sessions.kueue | object | `{}` |  |
-| deployment.skaha.sessions.limitRange.enabled | bool | `false` |  |
-| deployment.skaha.sessions.maxCount | string | `"5"` |  |
-| deployment.skaha.sessions.maxEphemeralStorage | string | `"200Gi"` |  |
-| deployment.skaha.sessions.minEphemeralStorage | string | `"20Gi"` |  |
-| deployment.skaha.sessions.nodeLabelSelector | string | `nil` |  |
-| deployment.skaha.sessions.tolerations | list | `[]` |  |
-| deployment.skaha.sessions.userStorage.admin.auth | string | `nil` |  |
-| deployment.skaha.sessions.userStorage.homeDirectory | string | `"home"` |  |
-| deployment.skaha.sessions.userStorage.persistentVolumeClaimName | string | `"skaha-workload-cavern-pvc"` |  |
-| deployment.skaha.sessions.userStorage.projectsDirectory | string | `"projects"` |  |
-| deployment.skaha.sessions.userStorage.topLevelDirectory | string | `"/cavern"` |  |
-| experimentalFeatures.enabled | bool | `false` |  |
+| deployment.hostname | string | `"myhost.example.com"` | Public hostname for the Skaha API. |
+| deployment.skaha.apiVersion | string | `"v1"` | Skaha API version path segment (for example, `v1` -> `/skaha/v1/...`). |
+| deployment.skaha.defaultQuotaGB | string | `"10"` | Default user storage quota in GiB for first-time users. |
+| deployment.skaha.identityManagerClass | string | `"org.opencadc.auth.StandardIdentityManager"` | Java IdentityManager implementation used for authentication. |
+| deployment.skaha.image | string | `"images.opencadc.org/platform/skaha:1.2.1"` | Container image for the Skaha API service. |
+| deployment.skaha.imageCache.refreshSchedule | string | `"*/30 * * * *"` | Cron schedule used to refresh cached images. |
+| deployment.skaha.imagePullPolicy | string | `"Always"` | Image pull policy for the Skaha API container. |
+| deployment.skaha.init.image | string | `"busybox:1.37.0"` | Init container image used to bootstrap user storage paths. |
+| deployment.skaha.init.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for the bootstrap init container. |
+| deployment.skaha.posixMapperCacheTTLSeconds | string | `"86400"` | TTL in seconds for cached POSIX mapper entries. |
+| deployment.skaha.priorityClassName | string | `"uber-user-preempt-high"` | PriorityClass assigned to the Skaha API Pod. |
+| deployment.skaha.registryHosts | string | `"images.canfar.net"` | Space-delimited list of image registry hosts allowed for sessions. |
+| deployment.skaha.resources.limits.cpu | string | `"2000m"` | CPU limit for the Skaha API container. |
+| deployment.skaha.resources.limits.memory | string | `"3Gi"` | Memory limit for the Skaha API container. |
+| deployment.skaha.resources.requests.cpu | string | `"1000m"` | CPU request for the Skaha API container. |
+| deployment.skaha.resources.requests.memory | string | `"2Gi"` | Memory request for the Skaha API container. |
+| deployment.skaha.serviceAccountName | string | `"skaha"` | ServiceAccount used by the Skaha API Pod. |
+| deployment.skaha.sessions.expirySeconds | string | `"345600"` | Session lifetime in seconds before expiry and shutdown. |
+| deployment.skaha.sessions.flexResourceRequests.headless.cpuCores | string | `"1"` | Default CPU request (cores) for flex headless sessions. |
+| deployment.skaha.sessions.flexResourceRequests.headless.memoryInGB | string | `"4"` | Default memory request (GiB) for flex headless sessions. |
+| deployment.skaha.sessions.imagePullPolicy | string | `"Always"` | Image pull policy applied to all user session containers. |
+| deployment.skaha.sessions.ingress.customResponseHeaders | object | `{}` | Custom response headers added to user-session ingress responses. |
+| deployment.skaha.sessions.ingress.tls | object | `{}` | TLS configuration for the user-session Traefik IngressRoute. |
+| deployment.skaha.sessions.initContainerImage | string | `"redis:8.2.2-bookworm"` | Image used by the session init container that manages POSIX data. |
+| deployment.skaha.sessions.kueue | object | `{}` | Per-session-type Kueue configuration. |
+| deployment.skaha.sessions.limitRange.enabled | bool | `false` | Enable creation of a LimitRange for session container resources. |
+| deployment.skaha.sessions.maxCount | string | `"5"` | Maximum number of active sessions allowed per user. |
+| deployment.skaha.sessions.maxEphemeralStorage | string | `"200Gi"` | Maximum ephemeral storage limit for sessions (non-desktop). |
+| deployment.skaha.sessions.minEphemeralStorage | string | `"20Gi"` | Initial ephemeral storage request for new sessions (non-desktop). |
+| deployment.skaha.sessions.nodeLabelSelector | string | `nil` | Node label selector used when discovering schedulable worker nodes. |
+| deployment.skaha.sessions.tolerations | list | `[]` | Tolerations applied to user session Pods. |
+| deployment.skaha.sessions.userStorage.admin.auth | string | `nil` | Authentication settings used for user-storage admin operations. |
+| deployment.skaha.sessions.userStorage.homeDirectory | string | `"home"` | Relative path under topLevelDirectory for user home directories. |
+| deployment.skaha.sessions.userStorage.persistentVolumeClaimName | string | `"skaha-workload-cavern-pvc"` | PVC name mounted into user sessions for persistent storage. |
+| deployment.skaha.sessions.userStorage.projectsDirectory | string | `"projects"` | Relative path under topLevelDirectory for shared projects storage. |
+| deployment.skaha.sessions.userStorage.topLevelDirectory | string | `"/cavern"` | Absolute mount path containing user home and projects directories. |
+| experimentalFeatures.enabled | bool | `false` | Enable processing of experimental feature gates. |
 | experimentalFeatures.sessionLimitRange | object | `{}` |  |
-| ingress.enabled | bool | `true` |  |
-| ingress.path | string | `"/skaha"` |  |
-| kubernetesClusterDomain | string | `"cluster.local"` |  |
-| podSecurityContext | object | `{}` |  |
-| redis.architecture | string | `"standalone"` |  |
-| redis.auth.enabled | bool | `false` |  |
-| redis.image.repository | string | `"redis"` |  |
-| redis.image.tag | string | `"8.2.2-bookworm"` |  |
-| redis.master.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
-| redis.master.containerSecurityContext.capabilities.drop[0] | string | `"ALL"` |  |
-| redis.master.containerSecurityContext.readOnlyRootFilesystem | bool | `true` |  |
-| redis.master.containerSecurityContext.runAsGroup | int | `1001` |  |
-| redis.master.containerSecurityContext.runAsNonRoot | bool | `true` |  |
-| redis.master.containerSecurityContext.runAsUser | int | `1001` |  |
-| redis.master.containerSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| redis.master.persistence.enabled | bool | `false` |  |
+| ingress.enabled | bool | `true` | Enable ingress routing for the Skaha API. |
+| ingress.path | string | `"/skaha"` | Ingress path prefix routed to the Skaha API Service. |
+| kubernetesClusterDomain | string | `"cluster.local"` | Kubernetes DNS domain used when building internal service hostnames. |
+| podSecurityContext | object | `{}` | Optional container-level security context for the Skaha API container. |
+| redis.architecture | string | `"standalone"` | Redis deployment architecture. |
+| redis.auth.enabled | bool | `false` | Enable Redis authentication. |
+| redis.image.repository | string | `"redis"` | Redis image repository used by the bundled chart dependency. |
+| redis.image.tag | string | `"8.2.2-bookworm"` | Redis image tag used by the bundled chart dependency. |
+| redis.master.containerSecurityContext.allowPrivilegeEscalation | bool | `false` | Disallow privilege escalation in the Redis master container. |
+| redis.master.containerSecurityContext.capabilities.drop | list | `["ALL"]` | Linux capabilities dropped from the Redis master container. |
+| redis.master.containerSecurityContext.readOnlyRootFilesystem | bool | `true` | Mount Redis master root filesystem as read-only. |
+| redis.master.containerSecurityContext.runAsGroup | int | `1001` | Group ID for the Redis master container. |
+| redis.master.containerSecurityContext.runAsNonRoot | bool | `true` | Require Redis master to run as a non-root user. |
+| redis.master.containerSecurityContext.runAsUser | int | `1001` | User ID for the Redis master container. |
+| redis.master.containerSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` | Seccomp profile type for Redis master. |
+| redis.master.persistence.enabled | bool | `false` | Enable persistence for the Redis master StatefulSet. |
 | replicaCount | int | `1` | Number of skaha-tomcat replicas when autoscaling is disabled. |
 | secrets | string | `nil` |  |
-| securityContext | object | `{}` |  |
-| service.port | int | `8080` |  |
-| skahaWorkload.namespace | string | `"skaha-workload"` |  |
-| tolerations | list | `[]` |  |
+| securityContext | object | `{}` | Optional Pod-level security context for the Skaha API Deployment. |
+| service.port | int | `8080` | Service port exposed for the Skaha API Service. |
+| skahaWorkload.namespace | string | `"skaha-workload"` | Workload namespace used for user session Jobs and related resources. |
+| tolerations | list | `[]` | Tolerations applied to the Skaha API Pod. |

--- a/helm/applications/skaha/README.md
+++ b/helm/applications/skaha/README.md
@@ -17,6 +17,9 @@ A Helm chart to install the Skaha web service of the CANFAR Science Platform
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| autoscaling.enabled | bool | `true` | Enable HorizontalPodAutoscaler for skaha-tomcat. Targets and scaling behavior are intentionally chart-managed (CPU 75%, memory 80%). |
+| autoscaling.maxReplicas | int | `6` | Maximum number of skaha-tomcat replicas. |
+| autoscaling.minReplicas | int | `1` | Minimum number of skaha-tomcat replicas. |
 | deployment.hostname | string | `"myhost.example.com"` |  |
 | deployment.skaha.apiVersion | string | `"v1"` |  |
 | deployment.skaha.defaultQuotaGB | string | `"10"` |  |
@@ -71,7 +74,7 @@ A Helm chart to install the Skaha web service of the CANFAR Science Platform
 | redis.master.containerSecurityContext.runAsUser | int | `1001` |  |
 | redis.master.containerSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | redis.master.persistence.enabled | bool | `false` |  |
-| replicaCount | int | `1` |  |
+| replicaCount | int | `1` | Number of skaha-tomcat replicas when autoscaling is disabled. |
 | secrets | string | `nil` |  |
 | securityContext | object | `{}` |  |
 | service.port | int | `8080` |  |

--- a/helm/applications/skaha/README.md
+++ b/helm/applications/skaha/README.md
@@ -17,9 +17,9 @@ A Helm chart to install the Skaha web service of the CANFAR Science Platform
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| autoscaling.enabled | bool | `true` | Enable HorizontalPodAutoscaler for skaha-tomcat. Targets and scaling behavior are intentionally chart-managed (CPU 75%, memory 80%). |
+| autoscaling.enabled | bool | `true` | Enable HorizontalPodAutoscaler for skaha-tomcat. Target and scaling behavior are intentionally chart-managed (CPU 65%). |
 | autoscaling.maxReplicas | int | `6` | Maximum number of skaha-tomcat replicas. |
-| autoscaling.minReplicas | int | `1` | Minimum number of skaha-tomcat replicas. |
+| autoscaling.minReplicas | int | `2` | Minimum number of skaha-tomcat replicas. |
 | deployment.hostname | string | `"myhost.example.com"` |  |
 | deployment.skaha.apiVersion | string | `"v1"` |  |
 | deployment.skaha.defaultQuotaGB | string | `"10"` |  |

--- a/helm/applications/skaha/templates/hpa.yaml
+++ b/helm/applications/skaha/templates/hpa.yaml
@@ -11,19 +11,19 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ .Release.Name }}-skaha-tomcat
-  minReplicas: {{ .Values.autoscaling.minReplicas | default 1 }}
+  minReplicas: {{ .Values.autoscaling.minReplicas | default 2 }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas | default 6 }}
   behavior:
     scaleUp:
-      stabilizationWindowSeconds: 60
+      stabilizationWindowSeconds: 0
       selectPolicy: Max
       policies:
       - type: Pods
-        value: 2
-        periodSeconds: 60
+        value: 4
+        periodSeconds: 30
       - type: Percent
         value: 100
-        periodSeconds: 60
+        periodSeconds: 30
     scaleDown:
       stabilizationWindowSeconds: 300
       selectPolicy: Min
@@ -40,11 +40,5 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: 75
-  - type: Resource
-    resource:
-      name: memory
-      target:
-        type: Utilization
-        averageUtilization: 80
+        averageUtilization: 65
 {{- end }}

--- a/helm/applications/skaha/templates/hpa.yaml
+++ b/helm/applications/skaha/templates/hpa.yaml
@@ -1,0 +1,50 @@
+{{- if (default false .Values.autoscaling.enabled) }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-skaha-tomcat
+  namespace: {{ .Release.Namespace }}
+  labels:
+    run: {{ .Release.Name }}-skaha-tomcat
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}-skaha-tomcat
+  minReplicas: {{ .Values.autoscaling.minReplicas | default 1 }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas | default 6 }}
+  behavior:
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      selectPolicy: Max
+      policies:
+      - type: Pods
+        value: 2
+        periodSeconds: 60
+      - type: Percent
+        value: 100
+        periodSeconds: 60
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      selectPolicy: Min
+      policies:
+      - type: Pods
+        value: 1
+        periodSeconds: 60
+      - type: Percent
+        value: 25
+        periodSeconds: 60
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 75
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 80
+{{- end }}

--- a/helm/applications/skaha/templates/skaha-tomcat-deployment.yaml
+++ b/helm/applications/skaha/templates/skaha-tomcat-deployment.yaml
@@ -6,7 +6,9 @@ metadata:
   name: {{ .Release.Name }}-skaha-tomcat
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- if not (default false .Values.autoscaling.enabled) }}
   replicas: {{ default 1 .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       run: {{ .Release.Name }}-skaha-tomcat

--- a/helm/applications/skaha/values.yaml
+++ b/helm/applications/skaha/values.yaml
@@ -4,8 +4,17 @@ kubernetesClusterDomain: cluster.local
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# Tell Kubernetes to spin up multiple instances.  Defaults to 1.
+# -- Number of skaha-tomcat replicas when autoscaling is disabled.
 replicaCount: 1
+
+autoscaling:
+  # -- Enable HorizontalPodAutoscaler for skaha-tomcat.
+  # Targets and scaling behavior are intentionally chart-managed (CPU 75%, memory 80%).
+  enabled: true
+  # -- Minimum number of skaha-tomcat replicas.
+  minReplicas: 1
+  # -- Maximum number of skaha-tomcat replicas.
+  maxReplicas: 6
 
 # It's best to keep this set as such, unless you're willing to change these in several places.
 skahaWorkload:

--- a/helm/applications/skaha/values.yaml
+++ b/helm/applications/skaha/values.yaml
@@ -1,3 +1,4 @@
+# -- Kubernetes DNS domain used when building internal service hostnames.
 kubernetesClusterDomain: cluster.local
 
 # Default values for skaha.
@@ -18,6 +19,7 @@ autoscaling:
 
 # It's best to keep this set as such, unless you're willing to change these in several places.
 skahaWorkload:
+  # -- Workload namespace used for user session Jobs and related resources.
   namespace: skaha-workload
 
 # @param securityContext - Optional security context for the container.  This is a security feature to restrict system calls.
@@ -27,6 +29,7 @@ skahaWorkload:
 # securityContext:
 #   seccompProfile:
 #     type: RuntimeDefault
+# -- Optional Pod-level security context for the Skaha API Deployment.
 securityContext: {}
 
 # @param podSecurityContext - Optional pod security context for the deployment.
@@ -37,33 +40,43 @@ securityContext: {}
 #   fsGroup: 1000
 #   runAsUser: 1000
 #   allowPrivilegeEscalation: false
+# -- Optional container-level security context for the Skaha API container.
 podSecurityContext: {}
 
 # Skaha web service deployment
 deployment:
+  # -- Public hostname for the Skaha API.
   hostname: myhost.example.com  # Change this!
   skaha:
+    # -- Container image for the Skaha API service.
     image: images.opencadc.org/platform/skaha:1.2.1
+    # -- Image pull policy for the Skaha API container.
     imagePullPolicy: Always
 
     # Cron string for the image caching cron job schedule. Defaults to every half hour.
     imageCache:
+      # -- Cron schedule used to refresh cached images.
       refreshSchedule: "*/30 * * * *"
 
     # Used when allocating first-time users into the system.
+    # -- Default user storage quota in GiB for first-time users.
     defaultQuotaGB: "10"
 
     # Space delimited list of allowed Image Registry hosts.  These hosts should match the hosts in the User Session images.
+    # -- Space-delimited list of image registry hosts allowed for sessions.
     registryHosts: "images.canfar.net"
 
     init:
       # The image to use for the init container.  Unless you have a reason to change this, leave it alone.
       # This image is used to create the /home and /projects directories, in case Cavern is not already running.
+      # -- Init container image used to bootstrap user storage paths.
       image: busybox:1.37.0
+      # -- Image pull policy for the bootstrap init container.
       imagePullPolicy: IfNotPresent
 
     # Optionally set the TTL (Time To Live) for POSIX Mapper cache entries, in seconds.  Defaults to 86400 seconds (1 day) if not set.
     # This is used to cache POSIX user and group information to reduce load on the POSIX Mapper service.
+    # -- TTL in seconds for cached POSIX mapper entries.
     posixMapperCacheTTLSeconds: "86400"
 
     # The IVOA GMS Group URI to verify users against for permission to use the Science Platform.
@@ -112,10 +125,18 @@ deployment:
     # Settings for User Sessions.  Sensible defaults supplied, but can be overridden.
     # For units of storage, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory.
     sessions:
-      expirySeconds: "345600"   # Duration, in seconds, until they expire and are shut down.
-      maxCount: "5"  # Max number of sessions per user.
-      minEphemeralStorage: "20Gi"   # The initial requested amount of ephemeral (local) storage.  Does NOT apply to Desktop sessions.
-      maxEphemeralStorage: "200Gi"  # The maximum amount of ephemeral (local) storage to allow a Session to extend to.  Does NOT apply to Desktop sessions.
+      # Duration, in seconds, until sessions expire and are shut down.
+      # -- Session lifetime in seconds before expiry and shutdown.
+      expirySeconds: "345600"
+      # Max number of sessions per user.
+      # -- Maximum number of active sessions allowed per user.
+      maxCount: "5"
+      # The initial requested amount of ephemeral (local) storage.  Does NOT apply to Desktop sessions.
+      # -- Initial ephemeral storage request for new sessions (non-desktop).
+      minEphemeralStorage: "20Gi"
+      # The maximum amount of ephemeral (local) storage to allow a Session to extend to.  Does NOT apply to Desktop sessions.
+      # -- Maximum ephemeral storage limit for sessions (non-desktop).
+      maxEphemeralStorage: "200Gi"
 
       # YAML to pass to a LimitRange object called "{{ .Release.Name }}-session-limit-range" in the workload Namespace to define the resource limits.
       # These limits will be applied to Container objects (User Sessions).
@@ -144,6 +165,7 @@ deployment:
       #       cpu: "1"
       #       "nvidia.com/gpu": "0"
       limitRange:
+        # -- Enable creation of a LimitRange for session container resources.
         enabled: false
 
       # Resource requests and limits for different session types for resource allocation when a "Flex" resource profile is used.
@@ -170,7 +192,9 @@ deployment:
       flexResourceRequests:
         # The headless session type resource requests get slightly more resources.
         headless:
+          # -- Default memory request (GiB) for flex headless sessions.
           memoryInGB: "4"
+          # -- Default CPU request (cores) for flex headless sessions.
           cpuCores: "1"
 
       # Storage setings to be passed into the User Session Kubernetes Job spec.
@@ -180,23 +204,27 @@ deployment:
         # Example:
         #   topLevelDirectory: "/cavern"
         #
+        # -- Absolute mount path containing user home and projects directories.
         topLevelDirectory: "/cavern"
 
         # Required.  RELATIVE path to the User Storage Home folder.  This is the folder where the User's home directories will be created.  Defaults to "home".
         # Example:
         #   homeDirectory: "home"
         #
+        # -- Relative path under topLevelDirectory for user home directories.
         homeDirectory: "home"
 
         # Required.  RELATIVE path to the User Storage Projects folder.  This is the folder where the Users can share data.  This is used for CARTA sessions.  Defaults to "projects".
         # Example:
         #   projectsDirectory: "projects"
         #
+        # -- Relative path under topLevelDirectory for shared projects storage.
         projectsDirectory: "projects"
 
         # Optional. Name of the Persistent Volume Claim to use for User Storage when mounted into sessions.  Defaults to "skaha-workload-cavern-pvc".
         # Example:
         #   persistentVolumeClaimName: "skaha-workload-cavern-pvc"
+        # -- PVC name mounted into user sessions for persistent storage.
         persistentVolumeClaimName: "skaha-workload-cavern-pvc"
 
         # Required.  The VOSpace Service URI (uses ivo:// scheme) for the Cavern Service.
@@ -212,6 +240,7 @@ deployment:
 
         # Required.  These are the credentials and details to connect to the Cavern service to provide Administrative access to User Storage, namely creating new allocations.
         admin:
+          # -- Authentication settings used for user-storage admin operations.
           auth:
             # Authenticate with an agreed API Key between Skaha and Cavern.  This is used to create new user home directories (allocations).
             # Generate Key:
@@ -234,6 +263,7 @@ deployment:
       # @see https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
       # Example:
       #   imagePullPolicy: IfNotPresent
+      # -- Image pull policy applied to all user session containers.
       imagePullPolicy: Always
 
       # Optionally configure the initContainer image for Redis.  Useful for those not able to reach docker.io
@@ -241,6 +271,7 @@ deployment:
       # Example:
       #   initContainerImage: "private-image-repo/project/my-own-redis:1.0"
       # initContainerImage:
+      # -- Image used by the session init container that manages POSIX data.
       initContainerImage: "redis:8.2.2-bookworm"
 
       # Optionally set the node label selector to identify Kubernetes Worker Nodes.  This is used to accurately query for available
@@ -254,12 +285,15 @@ deployment:
       #
       # Example (multiple labels ORed):
       #   nodeLabelSelector: "node-role.kubernetes.io/node-type in (worker,worker-gpu)"
+      # -- Node label selector used when discovering schedulable worker nodes.
       nodeLabelSelector:
 
       # Optionally configure the Kueue system to handle large workloads.  Configurable per session type (e.g. desktop, notebook, etc.).
       # Leaving this empty will default to submitting Jobs to the base Kubernetes system.
       # Provide a default configuration for all session types, or omit and only configure specific session types.
       # Provided PriorityClass names are "high", "medium", and "low".
+      # Configure Kueue queues and priority classes for session scheduling.
+      # Leaving this empty uses the base Kubernetes scheduler.
       # @see https://kueue.sigs.k8s.io/docs/
       # @see https://github.com/opencadc/deployments/tree/main/configs/kueue
       # Example 1:
@@ -288,6 +322,7 @@ deployment:
       #      default:
       #        queueName: "all-user-sessions-local-queue"
       #        priorityClass: "medium"
+      # -- Per-session-type Kueue configuration.
       kueue: {}
 
       # This is a list of tolerations that will be added to the Pod spec of the User Sessions.
@@ -301,6 +336,7 @@ deployment:
       #   value: "value1"
       #   effect: "NoSchedule"
       #
+      # -- Tolerations applied to user session Pods.
       tolerations: []
 
       # Optionally setup a separate host for User Sessions for Skaha to redirect to.  The HTTPS scheme is assumed.  Defaults to the Skaha hostname.
@@ -314,12 +350,14 @@ deployment:
         # Example:
         #   tls:
         #     secretName: myhost-tls-secret
+        # -- TLS configuration for the user-session Traefik IngressRoute.
         tls: {}
 
         # Add custom response headers to User Sessions.  This is useful for Science Gateway embedding support.
         # Example:
         #   customResponseHeaders:
         #     content-security-policy: "frame-ancestors 'self' https://gateway.example.org"
+        # -- Custom response headers added to user-session ingress responses.
         customResponseHeaders: {}
 
       # Declare extra volume mounts in User Sessions.  The "type: parameter in volume section is constant.
@@ -372,12 +410,17 @@ deployment:
 
     # Resources provided to the Skaha service.
     # For units of storage, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory.
+    # Resources provided to the Skaha API container.
     resources:
       requests:
+        # -- Memory request for the Skaha API container.
         memory: "2Gi"
+        # -- CPU request for the Skaha API container.
         cpu: "1000m"
       limits:
+        # -- Memory limit for the Skaha API container.
         memory: "3Gi"
+        # -- CPU limit for the Skaha API container.
         cpu: "2000m"
 
     # Uncomment to debug.  Requires options above as well as service port exposure below.
@@ -391,10 +434,13 @@ deployment:
     #   name: cacert-volume
 
     # If the base names have changed, then change them here, otherwise leave them.
+    # -- PriorityClass assigned to the Skaha API Pod.
     priorityClassName: uber-user-preempt-high
+    # -- ServiceAccount used by the Skaha API Pod.
     serviceAccountName: skaha
 
     # The IdentityManager class handling authentication.  This should generally be left alone
+    # -- Java IdentityManager implementation used for authentication.
     identityManagerClass: org.opencadc.auth.StandardIdentityManager
 
     # Create the CA certificate volume to be mounted in extraVolumeMounts
@@ -408,6 +454,7 @@ deployment:
     # This the version that will show up in the path for the request (e.g. '/skaha/v0/session').
     # Example:
     #   apiVersion: 'v0'
+    # -- Skaha API version path segment (for example, `v1` -> `/skaha/v1/...`).
     apiVersion: 'v1'
 
   # Specify extra hostnames that will be added to the Pod's /etc/hosts file.  Note that this is in the
@@ -428,24 +475,29 @@ deployment:
 #   value: "value1"
 #   effect: "NoSchedule"
 #
+# -- Tolerations applied to the Skaha API Pod.
 tolerations: []
 
-# Port to expose from the service.  This will ultimately serve port 8080 (default Tomcat port), but will
-# be exposed as per the port below.  Useful for running multiple deployments side-by-side.
-# Defaults to 8080.
-# Example:
-#   service:
-#     port: 8081. # To map port 8081 to port 8080.
 service:
+  # Port to expose from the service.  This will ultimately serve port 8080 (default Tomcat port), but will
+  # be exposed as per the port below.  Useful for running multiple deployments side-by-side.
+  # Defaults to 8080.
+  # Example:
+  #   service:
+  #     port: 8081. # To map port 8081 to port 8080.
+  # -- Service port exposed for the Skaha API Service.
   port: 8080
 
-# Selectively disable ingress if desired.  This is enabled by default.
 ingress:
+  # Selectively disable ingress if desired.  This is enabled by default.
+  # -- Enable ingress routing for the Skaha API.
   enabled: true
+  # -- Ingress path prefix routed to the Skaha API Service.
   path: /skaha
 
-# Experimental features that can be enabled.  These represent features that are not released and confined behind feature flags.
 experimentalFeatures:
+  # Experimental features that can be enabled.  These represent features that are not released and confined behind feature flags.
+  # -- Enable processing of experimental feature gates.
   enabled: false
 
   # @deprecated Use deployment.skaha.sessions.limitRange instead.  Here for backward compatibility.
@@ -459,21 +511,33 @@ secrets:
 # For caching images from the Image Repository and for the writing the POSIX Users and Groups to be shared with Job files
 redis:
   image:
+    # -- Redis image repository used by the bundled chart dependency.
     repository: redis
+    # -- Redis image tag used by the bundled chart dependency.
     tag: 8.2.2-bookworm
+  # -- Redis deployment architecture.
   architecture: 'standalone'
   auth:
+    # -- Enable Redis authentication.
     enabled: false
   master:
     persistence:
+      # -- Enable persistence for the Redis master StatefulSet.
       enabled: false
     containerSecurityContext:
+      # -- User ID for the Redis master container.
       runAsUser: 1001
+      # -- Group ID for the Redis master container.
       runAsGroup: 1001
+      # -- Require Redis master to run as a non-root user.
       runAsNonRoot: true
+      # -- Disallow privilege escalation in the Redis master container.
       allowPrivilegeEscalation: false
+      # -- Mount Redis master root filesystem as read-only.
       readOnlyRootFilesystem: true
       seccompProfile:
+        # -- Seccomp profile type for Redis master.
         type: RuntimeDefault
       capabilities:
+        # -- Linux capabilities dropped from the Redis master container.
         drop: ["ALL"]

--- a/helm/applications/skaha/values.yaml
+++ b/helm/applications/skaha/values.yaml
@@ -9,10 +9,10 @@ replicaCount: 1
 
 autoscaling:
   # -- Enable HorizontalPodAutoscaler for skaha-tomcat.
-  # Targets and scaling behavior are intentionally chart-managed (CPU 75%, memory 80%).
+  # Target and scaling behavior are intentionally chart-managed (CPU 65%).
   enabled: true
   # -- Minimum number of skaha-tomcat replicas.
-  minReplicas: 1
+  minReplicas: 2
   # -- Maximum number of skaha-tomcat replicas.
   maxReplicas: 6
 


### PR DESCRIPTION
## Summary
- add chart-managed HPA for `skaha-tomcat`
- make Deployment replicas conditional so HPA controls scaling when enabled
- keep deployer-facing autoscaling inputs minimal (`enabled`, `minReplicas`, `maxReplicas`) and chart-manage scaling behavior/targets
- tune HPA for faster scale-up and conservative scale-down using CPU utilization
- improve `values.yaml` comments and regenerate chart README via helm-docs

## Validation
- `uv run pre-commit run -a`
- `helm lint helm/applications/skaha`
- `helm template` render checks for HPA/deployment behavior

Refs: CADC-15119
