### PR TITLE
fix(skaha): use carta probe path with trailing slash

### DIFF
--- a/helm/applications/skaha/skaha-config/launch-carta.yaml
+++ b/helm/applications/skaha/skaha-config/launch-carta.yaml
@@ -77,17 +77,17 @@ spec:
             ephemeral-storage: "{{ .Values.deployment.skaha.sessions.maxEphemeralStorage }}"
         livenessProbe:
           httpGet:
-            path: "${skaha.sessionurlpath}"
+            path: "${skaha.sessionurlpath}/"
             port: 6901
           periodSeconds: 10
         readinessProbe:
           httpGet:
-            path: "${skaha.sessionurlpath}"
+            path: "${skaha.sessionurlpath}/"
             port: 6901
           periodSeconds: 15
         startupProbe:
           httpGet:
-            path: "${skaha.sessionurlpath}"
+            path: "${skaha.sessionurlpath}/"
             port: 6901
           initialDelaySeconds: 10
           timeoutSeconds: 300


### PR DESCRIPTION
## Summary

Update CARTA session liveness/readiness/startup probes to request `${skaha.sessionurlpath}/` instead of `${skaha.sessionurlpath}`.

## Verification

Tested with a staging CARTA session using `images.canfar.net/skaha/carta:5.1.0-skaha-fix`.

The image startup config is working and CARTA starts with the Skaha session settings:

```text
start.sh: command=carta --no_browser --top_level_folder=/arc --enable_scripting --host=0.0.0.0 --port=6901 --idle_timeout=100000 --debug_no_auth --http_url_prefix=/session/carta/fltrnszv /arc/projects
Listening on port 6901 ...
CARTA is accessible at http://10.224.22.100:6901/session/carta/fltrnszv/
```

From inside the CARTA container:

```text
GET /session/carta/fltrnszv  -> HTTP 404
GET /session/carta/fltrnszv/ -> HTTP 200
```

This matches the kubelet startup probe failure and shows the remaining failure is the probe path, not the CARTA image startup configuration.