### PR TITLE
feat(helm): add DOI service chart

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -7,5 +7,6 @@
   "helm/applications/storage-ui": "0.9.0",
   "helm/applications/utils": "0.1.1",
   "helm/applications/reg": "1.0.0",
+  "helm/applications/doi": "0.1.0",
   "helm/common": "1.0.0"
 }

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ This section is automatically generated. Do not edit manually.
 | Chart | Description |
 | --- | --- |
 | [access](helm/applications/access) | A Helm chart for the Access web service, responsible for managing user cookie access CADC and CANFAR services and applications. |
-| [scienceportal](helm/applications/archived/science-portal) | A Helm chart to install the Science Portal UI (legacy) |
-| [science-portal](https://github.com/opencadc/science-portal/blob/main/helm) | The current version of the Science Portal UI |
+| [scienceportal](helm/applications/archived/science-portal) | A Helm chart to install the Science Portal UI |
 | [skaha](helm/applications/archived/skaha) | A Helm chart to install the Skaha web service of the CANFAR Science Platform |
 | [canfar-web-portal](helm/applications/canfar-web-portal) | A Helm chart for Kubernetes |
 | [canfar-web-root](helm/applications/canfar-web-root) | A Helm chart for Kubernetes |
 | [cavern](helm/applications/cavern) | A Helm chart to install the VOSpace User Storage API (Cavern) |
+| [doi](helm/applications/doi) | A Helm chart to install the Digital Object Identifier service |
 | [posixmapper](helm/applications/posix-mapper) | A Helm chart to install the UID/GID POSIX Mapper |
 | [reg](helm/applications/reg) | IVOA Registry Service Helm Chart |
 | [argus](helm/applications/sandbox/argus) | An IVAO TAP Helm chart |

--- a/helm/applications/doi/.helmignore
+++ b/helm/applications/doi/.helmignore
@@ -1,0 +1,7 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.helmignore
+*.swp
+*.tmp

--- a/helm/applications/doi/Chart.lock
+++ b/helm/applications/doi/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: utils
+  repository: file://../utils
+  version: 0.1.2
+digest: sha256:98ec11c0ba13f64e79481985688c2e0354c5eeb3fca6b65b3e4953a08644710a
+generated: "2026-07-02T22:01:37.708481-07:00"

--- a/helm/applications/doi/Chart.yaml
+++ b/helm/applications/doi/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: doi
+description: "A Helm chart to install the Digital Object Identifier service"
+
+maintainers:
+  - name: Canadian Astronomy Data Centre
+    email: cadc@nrc-cnrc.gc.ca
+
+type: application
+
+version: 0.1.0
+
+# renovate: image=images.opencadc.org/platform/doi
+appVersion: "1.2.0"
+
+dependencies:
+  - name: "utils"
+    version: "^0.1.0"
+    repository: "file://../utils"

--- a/helm/applications/doi/README.md
+++ b/helm/applications/doi/README.md
@@ -1,0 +1,84 @@
+# doi
+
+Digital Object Identifier service Helm chart.
+
+This chart deploys the CADC DOI Tomcat service. Non-secret configuration is rendered into a ConfigMap under `/config`; DataCite credentials and the required `doiadmin.pem` and `cadcproxy.pem` files are read from Kubernetes Secrets and merged into the runtime config by an init container.
+
+## Required Secrets
+
+Create a Secret for DataCite credentials:
+
+```shell
+kubectl create secret generic doi-datacite \
+  --from-literal=username='<username>' \
+  --from-literal=password='<password>'
+```
+
+Create a Secret for service certificates:
+
+```shell
+kubectl create secret generic doi-certs \
+  --from-file=doiadmin.pem=./doiadmin.pem \
+  --from-file=cadcproxy.pem=./cadcproxy.pem
+```
+
+Set:
+
+```yaml
+deployment:
+  doi:
+    datacite:
+      auth:
+        existingSecret: doi-datacite
+    certificates:
+      existingSecret: doi-certs
+```
+
+## Example Values
+
+Start from `examples/values.example.yaml` and replace the example hostnames, registry IDs, VOSpace URI, DataCite account prefix, and Secret names.
+
+## Test the Chart
+
+Render and lint the chart with non-secret placeholder Secret names:
+
+```shell
+helm lint helm/applications/doi \
+  --set deployment.doi.datacite.auth.existingSecret=doi-datacite \
+  --set deployment.doi.certificates.existingSecret=doi-certs \
+  --set deployment.doi.config.accountPrefix=10.5072
+
+helm template doi helm/applications/doi \
+  --namespace doi \
+  --set deployment.doi.datacite.auth.existingSecret=doi-datacite \
+  --set deployment.doi.certificates.existingSecret=doi-certs \
+  --set deployment.doi.config.accountPrefix=10.5072
+```
+
+Dry-run against a cluster:
+
+```shell
+helm upgrade --install doi helm/applications/doi \
+  --namespace doi \
+  --create-namespace \
+  --values helm/applications/doi/examples/values.example.yaml \
+  --dry-run
+```
+
+Install after replacing the example values and creating the required Secrets:
+
+```shell
+helm upgrade --install doi helm/applications/doi \
+  --namespace doi \
+  --create-namespace \
+  --values <your-values.yaml>
+```
+
+Check the workload:
+
+```shell
+kubectl -n doi get pods
+kubectl -n doi logs deploy/doi-tomcat
+kubectl -n doi port-forward svc/doi-tomcat-svc 18080:8080
+curl http://localhost:18080/doi/availability
+```

--- a/helm/applications/doi/README.md.gotmpl
+++ b/helm/applications/doi/README.md.gotmpl
@@ -1,0 +1,84 @@
+# doi
+
+Digital Object Identifier service Helm chart.
+
+This chart deploys the CADC DOI Tomcat service. Non-secret configuration is rendered into a ConfigMap under `/config`; DataCite credentials and the required `doiadmin.pem` and `cadcproxy.pem` files are read from Kubernetes Secrets and merged into the runtime config by an init container.
+
+## Required Secrets
+
+Create a Secret for DataCite credentials:
+
+```shell
+kubectl create secret generic doi-datacite \
+  --from-literal=username='<username>' \
+  --from-literal=password='<password>'
+```
+
+Create a Secret for service certificates:
+
+```shell
+kubectl create secret generic doi-certs \
+  --from-file=doiadmin.pem=./doiadmin.pem \
+  --from-file=cadcproxy.pem=./cadcproxy.pem
+```
+
+Set:
+
+```yaml
+deployment:
+  doi:
+    datacite:
+      auth:
+        existingSecret: doi-datacite
+    certificates:
+      existingSecret: doi-certs
+```
+
+## Example Values
+
+Start from `examples/values.example.yaml` and replace the example hostnames, registry IDs, VOSpace URI, DataCite account prefix, and Secret names.
+
+## Test the Chart
+
+Render and lint the chart with non-secret placeholder Secret names:
+
+```shell
+helm lint helm/applications/doi \
+  --set deployment.doi.datacite.auth.existingSecret=doi-datacite \
+  --set deployment.doi.certificates.existingSecret=doi-certs \
+  --set deployment.doi.config.accountPrefix=10.5072
+
+helm template doi helm/applications/doi \
+  --namespace doi \
+  --set deployment.doi.datacite.auth.existingSecret=doi-datacite \
+  --set deployment.doi.certificates.existingSecret=doi-certs \
+  --set deployment.doi.config.accountPrefix=10.5072
+```
+
+Dry-run against a cluster:
+
+```shell
+helm upgrade --install doi helm/applications/doi \
+  --namespace doi \
+  --create-namespace \
+  --values helm/applications/doi/examples/values.example.yaml \
+  --dry-run
+```
+
+Install after replacing the example values and creating the required Secrets:
+
+```shell
+helm upgrade --install doi helm/applications/doi \
+  --namespace doi \
+  --create-namespace \
+  --values <your-values.yaml>
+```
+
+Check the workload:
+
+```shell
+kubectl -n doi get pods
+kubectl -n doi logs deploy/doi-tomcat
+kubectl -n doi port-forward svc/doi-tomcat-svc 18080:8080
+curl http://localhost:18080/doi/availability
+```

--- a/helm/applications/doi/config/cadc-log.properties
+++ b/helm/applications/doi/config/cadc-log.properties
@@ -1,0 +1,3 @@
+{{- range $val := .Values.deployment.doi.loggingGroups }}
+group = {{ $val }}
+{{- end }}

--- a/helm/applications/doi/config/cadc-registry.properties
+++ b/helm/applications/doi/config/cadc-registry.properties
@@ -1,0 +1,21 @@
+#
+# local authority map
+#
+{{- with .Values.deployment.doi.gmsID }}
+ivo://ivoa.net/std/GMS#search-1.0 = {{ . }}
+ivo://ivoa.net/std/GMS#search-0.1 = {{ . }}
+ivo://ivoa.net/std/GMS#users-1.0 = {{ . }}
+ivo://ivoa.net/std/UMS#users-0.1 = {{ . }}
+ivo://ivoa.net/std/UMS#users-1.0 = {{ . }}
+ivo://ivoa.net/sso#tls-with-password = {{ . }}
+{{- end }}
+{{- with .Values.deployment.doi.oidcURI }}
+ivo://ivoa.net/sso#OAuth = {{ . }}
+ivo://ivoa.net/sso#OpenID = {{ . }}
+{{- end }}
+
+{{- $raw := .Values.deployment.doi.registryURL -}}
+{{- $urls := ternary (list $raw) $raw (kindIs "string" $raw) -}}
+{{- range $urls }}
+ca.nrc.cadc.reg.client.RegistryClient.baseURL = {{ . }}
+{{- end }}

--- a/helm/applications/doi/config/catalina.properties
+++ b/helm/applications/doi/config/catalina.properties
@@ -1,0 +1,10 @@
+tomcat.connector.connectionTimeout=180000
+tomcat.connector.keepAliveTimeout=180000
+tomcat.connector.secure=true
+tomcat.connector.scheme=https
+tomcat.connector.proxyName={{ .Values.deployment.hostname }}
+tomcat.connector.proxyPort=443
+ca.nrc.cadc.auth.PrincipalExtractor.enableClientCertHeader=true
+ca.nrc.cadc.util.Log4jInit.messageOnly=true
+# (default: ca.nrc.cadc.auth.NoOpIdentityManager)
+ca.nrc.cadc.auth.IdentityManager={{ .Values.deployment.doi.identityManagerClass }}

--- a/helm/applications/doi/config/doi.properties
+++ b/helm/applications/doi/config/doi.properties
@@ -1,0 +1,19 @@
+ca.nrc.cadc.doi.vospaceParentUri = {{ .Values.deployment.doi.config.vospaceParentUri | required ".Values.deployment.doi.config.vospaceParentUri is required" }}
+ca.nrc.cadc.doi.metaDataPrefix = {{ .Values.deployment.doi.config.metaDataPrefix | required ".Values.deployment.doi.config.metaDataPrefix is required" }}
+ca.nrc.cadc.doi.groupPrefix = {{ .Values.deployment.doi.config.groupPrefix | required ".Values.deployment.doi.config.groupPrefix is required" }}
+ca.nrc.cadc.doi.landingUrl = {{ .Values.deployment.doi.config.landingUrl | required ".Values.deployment.doi.config.landingUrl is required" }}
+ca.nrc.cadc.doi.datacite.mdsUrl = {{ .Values.deployment.doi.config.mdsUrl | required ".Values.deployment.doi.config.mdsUrl is required" }}
+ca.nrc.cadc.doi.datacite.accountPrefix = {{ .Values.deployment.doi.config.accountPrefix | required ".Values.deployment.doi.config.accountPrefix is required" }}
+{{- with .Values.deployment.doi.config.doiIdentifierPrefix }}
+ca.nrc.cadc.doi.doiIdentifierPrefix = {{ . }}
+{{- end }}
+{{- with .Values.deployment.doi.config.publisherGroupURI }}
+ca.nrc.cadc.doi.publisherGroupURI = {{ . }}
+{{- end }}
+{{- with .Values.deployment.doi.config.selfPublish }}
+ca.nrc.cadc.doi.selfPublish = {{ . }}
+{{- end }}
+{{- if .Values.deployment.doi.config.randomTestID }}
+ca.nrc.cadc.doi.randomTestID = true
+{{- end }}
+# ca.nrc.cadc.doi.datacite.username and ca.nrc.cadc.doi.datacite.password are appended at pod startup from Secret {{ include "doi.dataciteAuthSecretName" . }}.

--- a/helm/applications/doi/config/war-rename.conf
+++ b/helm/applications/doi/config/war-rename.conf
@@ -1,0 +1,3 @@
+{{- if and .Values.deployment.doi.applicationName (ne .Values.deployment.doi.applicationName "doi") }}
+mv doi.war {{ .Values.deployment.doi.applicationName }}.war
+{{- end }}

--- a/helm/applications/doi/examples/values.example.yaml
+++ b/helm/applications/doi/examples/values.example.yaml
@@ -1,0 +1,28 @@
+# Example values for deploying the DOI service.
+#
+# Copy this file and replace the example values with your environment-specific
+# hostnames, registry IDs, VOSpace URI, DataCite account, and Secret names.
+
+deployment:
+  hostname: doi.example.org
+  doi:
+    image: images.opencadc.org/platform/doi:1.2.0
+
+    registryURL: https://doi.example.org/reg
+    gmsID: ivo://example.org/gms
+    oidcURI: https://iam.example.org/
+
+    config:
+      vospaceParentUri: vos://example.org~arc/doi
+      metaDataPrefix: doi
+      groupPrefix: doi
+      landingUrl: https://doi.example.org/doi
+      mdsUrl: https://mds.datacite.org
+      accountPrefix: "10.5072"
+
+    datacite:
+      auth:
+        existingSecret: doi-datacite
+
+    certificates:
+      existingSecret: doi-certs

--- a/helm/applications/doi/templates/NOTES.txt
+++ b/helm/applications/doi/templates/NOTES.txt
@@ -1,0 +1,13 @@
+'{{ .Chart.Name }}' installed successfully. You can monitor it in the {{ .Release.Namespace }} Namespace:
+
+kubectl -n {{ .Release.Namespace }} get pods
+
+Your release is named {{ .Release.Name }}.
+
+The DOI service expects DataCite credentials from Secret {{ include "doi.dataciteAuthSecretName" . }}
+and PEM certificates from Secret {{ include "doi.certificateSecretName" . }}.
+
+To learn more about the release, try:
+
+  $ helm -n {{ .Release.Namespace }} status {{ .Release.Name }}
+  $ helm -n {{ .Release.Namespace }} get all {{ .Release.Name }}

--- a/helm/applications/doi/templates/_helpers.tpl
+++ b/helm/applications/doi/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "doi.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "doi.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "doi.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "doi.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "doi.labels" -}}
+helm.sh/chart: {{ include "doi.chart" . }}
+{{ include "doi.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+DataCite credential Secret name.
+*/}}
+{{- define "doi.dataciteAuthSecretName" -}}
+{{- required "deployment.doi.datacite.auth.existingSecret is required" .Values.deployment.doi.datacite.auth.existingSecret -}}
+{{- end -}}
+
+{{/*
+PEM certificate Secret name.
+*/}}
+{{- define "doi.certificateSecretName" -}}
+{{- required "deployment.doi.certificates.existingSecret is required" .Values.deployment.doi.certificates.existingSecret -}}
+{{- end -}}

--- a/helm/applications/doi/templates/configmap.yaml
+++ b/helm/applications/doi/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "doi.labels" . | nindent 4 }}
+data:
+{{ tpl (.Files.Glob "config/*").AsConfig . | indent 2 }}
+{{- include "utils.extraConfig" (dict "extraConfigData" .Values.deployment.doi.extraConfigData) -}}

--- a/helm/applications/doi/templates/deployment.yaml
+++ b/helm/applications/doi/templates/deployment.yaml
@@ -1,0 +1,154 @@
+{{- $containerPort := 8080 -}}
+{{- $auth := .Values.deployment.doi.datacite.auth | default dict -}}
+{{- $authKeys := $auth.secretKeys | default dict -}}
+{{- $usernameKey := $authKeys.username | default "username" -}}
+{{- $passwordKey := $authKeys.password | default "password" -}}
+{{- $certs := .Values.deployment.doi.certificates | default dict -}}
+{{- $certKeys := $certs.secretKeys | default dict -}}
+{{- $doiadminKey := $certKeys.doiadmin | default "doiadmin.pem" -}}
+{{- $cadcproxyKey := $certKeys.cadcproxy | default "cadcproxy.pem" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    run: {{ .Release.Name }}-tomcat
+    {{- include "doi.labels" . | nindent 4 }}
+  name: {{ .Release.Name }}-tomcat
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ default 1 .Values.replicaCount }}
+  selector:
+    matchLabels:
+      run: {{ .Release.Name }}-tomcat
+  template:
+    metadata:
+      labels:
+        run: {{ .Release.Name }}-tomcat
+        {{- include "doi.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.deployment.doi.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.doi.nodeAffinity }}
+      affinity:
+        nodeAffinity:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
+      {{- $podSC := merge (.Values.volumeInit.podSecurityContext | default dict) (.Values.podSecurityContext | default dict) }}
+      {{- if not (empty $podSC) }}
+      securityContext:
+        {{- toYaml $podSC | nindent 8 }}
+      {{- end }}
+      initContainers:
+        - name: merge-doi-config
+          image: {{ .Values.volumeInit.image | quote }}
+          imagePullPolicy: {{ .Values.volumeInit.imagePullPolicy }}
+          command: ['sh', '-c']
+          args:
+            - |
+              set -e
+              cp -R /config-src/. /config-dst/
+              cp "/certs/${DOIADMIN_KEY}" /config-dst/doiadmin.pem
+              cp "/certs/${CADCPROXY_KEY}" /config-dst/cadcproxy.pem
+              USER=$(tr -d '\n' < "/datacite/${USERNAME_KEY}")
+              PASS=$(tr -d '\n' < "/datacite/${PASSWORD_KEY}")
+              printf '\nca.nrc.cadc.doi.datacite.username = %s\n' "$USER" >> /config-dst/doi.properties
+              printf 'ca.nrc.cadc.doi.datacite.password = %s\n' "$PASS" >> /config-dst/doi.properties
+          env:
+            - name: USERNAME_KEY
+              value: {{ $usernameKey | quote }}
+            - name: PASSWORD_KEY
+              value: {{ $passwordKey | quote }}
+            - name: DOIADMIN_KEY
+              value: {{ $doiadminKey | quote }}
+            - name: CADCPROXY_KEY
+              value: {{ $cadcproxyKey | quote }}
+          volumeMounts:
+            - name: config-source
+              mountPath: /config-src
+              readOnly: true
+            - name: datacite-secret
+              mountPath: /datacite
+              readOnly: true
+            - name: certificate-secret
+              mountPath: /certs
+              readOnly: true
+            - name: config-merged
+              mountPath: /config-dst
+          {{- with .Values.volumeInit.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      containers:
+        - image: {{ .Values.deployment.doi.image }}
+          imagePullPolicy: {{ .Values.deployment.doi.imagePullPolicy }}
+          name: {{ .Release.Name }}-tomcat
+          resources:
+            requests:
+              memory: {{ .Values.deployment.doi.resources.requests.memory }}
+              cpu: {{ .Values.deployment.doi.resources.requests.cpu }}
+            limits:
+              memory: {{ .Values.deployment.doi.resources.limits.memory }}
+              cpu: {{ .Values.deployment.doi.resources.limits.cpu }}
+          securityContext:
+            {{- $tomcatSC := merge (dict "allowPrivilegeEscalation" false) (.Values.securityContext | default dict) }}
+            {{- toYaml $tomcatSC | nindent 12 }}
+          {{- with .Values.deployment.doi.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - containerPort: {{ $containerPort }}
+              protocol: TCP
+          {{- with .Values.deployment.doi.extraPorts }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - mountPath: "/config"
+              name: config-merged
+          {{- with .Values.deployment.doi.extraVolumeMounts }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.deployment.extraHosts }}
+      hostAliases:
+      {{- range $extraHost := . }}
+        - ip: {{ $extraHost.ip }}
+          hostnames:
+            - {{ $extraHost.hostname }}
+      {{- end }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.serviceAccount.name }}
+      serviceAccountName: {{ . }}
+      {{- end }}
+      volumes:
+        - name: config-source
+          configMap:
+            name: {{ .Release.Name }}-config
+        - name: datacite-secret
+          secret:
+            secretName: {{ include "doi.dataciteAuthSecretName" . }}
+        - name: certificate-secret
+          secret:
+            secretName: {{ include "doi.certificateSecretName" . }}
+        - name: config-merged
+          emptyDir: {}
+      {{- with .Values.deployment.doi.extraVolumes }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/applications/doi/templates/ingress.yaml
+++ b/helm/applications/doi/templates/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "doi.labels" . | nindent 4 }}
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: {{ .Values.deployment.hostname }}
+      http:
+        paths:
+          - path: {{ .Values.deployment.doi.endpoint | default "/doi" }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-tomcat-svc
+                port:
+                  number: 8080

--- a/helm/applications/doi/templates/service.yaml
+++ b/helm/applications/doi/templates/service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-tomcat-svc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    run: {{ .Release.Name }}-tomcat-svc
+    {{- include "doi.labels" . | nindent 4 }}
+spec:
+  ports:
+    - port: 8080
+      name: http-connection
+      protocol: TCP
+    - port: 80
+      targetPort: 8080
+      name: http-connection-automatic
+      protocol: TCP
+  {{- with .Values.service }}
+    {{- with .extraPorts }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  selector:
+    run: {{ .Release.Name }}-tomcat

--- a/helm/applications/doi/templates/serviceaccount.yaml
+++ b/helm/applications/doi/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name | required "serviceAccount.name is required when serviceAccount.create is true" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "doi.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm/applications/doi/templates/tests/test-connection.yaml
+++ b/helm/applications/doi/templates/tests/test-connection.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-test-connection"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "doi.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ .Release.Name }}-tomcat-svc:8080{{ .Values.deployment.doi.endpoint | default "/doi" }}/availability']
+  restartPolicy: Never

--- a/helm/applications/doi/values.yaml
+++ b/helm/applications/doi/values.yaml
@@ -1,0 +1,153 @@
+kubernetesClusterDomain: cluster.local
+
+replicaCount: 1
+
+podSecurityContext: {}
+
+securityContext: {}
+
+deployment:
+  hostname: example.org
+  doi:
+    image: images.opencadc.org/platform/doi:1.2.0
+    imagePullPolicy: IfNotPresent
+
+    # Optional rename of the application from the default "doi".
+    applicationName: "doi"
+
+    # The endpoint to serve this from. If applicationName is changed, this should match.
+    endpoint: "/doi"
+
+    # Set the Registry URL pointing to the desired registry (https:// URL).
+    # registryURL: https://example.org/reg
+
+    # ID (URI) of the GMS Service. Required for auth-related registry lookups.
+    # gmsID: ivo://example.org/gms
+
+    # URI or URL of the OIDC (IAM) server. Used to validate incoming tokens.
+    # oidcURI: https://example.org/oidc
+
+    # The IdentityManager class handling authentication.
+    identityManagerClass: org.opencadc.auth.StandardIdentityManager
+
+    config:
+      # VOSpace URI to the parent DOI folder.
+      vospaceParentUri: "vos://example.org~arc/doi"
+
+      # Prefix prepended to the DOI name for metadata stored in VOSpace.
+      metaDataPrefix: "doi"
+
+      # Prefix prepended to the DOI name to create the backing GMS group name.
+      groupPrefix: "doi"
+
+      # DOI landing page URL.
+      landingUrl: "https://example.org/doi"
+
+      # DataCite MDS REST endpoint.
+      mdsUrl: "https://mds.datacite.org"
+
+      # Registered prefix for the DataCite account.
+      accountPrefix: ""
+
+      # Optional DOI identifier prefix.
+      doiIdentifierPrefix: ""
+
+      # Optional publisher group URI for alternative DOI settings.
+      publisherGroupURI: ""
+
+      # Optional self-publish flag for alternative DOI settings.
+      selfPublish: ""
+
+      # Developer testing only.
+      randomTestID: false
+
+    datacite:
+      auth:
+        # Existing Secret containing DataCite credentials.
+        existingSecret: ""
+        secretKeys:
+          username: username
+          password: password
+
+    certificates:
+      # Existing Secret containing doiadmin.pem and cadcproxy.pem.
+      existingSecret: ""
+      secretKeys:
+        doiadmin: doiadmin.pem
+        cadcproxy: cadcproxy.pem
+
+    # Optionally set the DEBUG port.
+    # extraEnv:
+    # - name: CATALINA_OPTS
+    #   value: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:5555"
+    # extraPorts:
+    # - containerPort: 5555
+    #   protocol: TCP
+
+    # This applies to the DOI service pod.
+    # nodeAffinity: {}
+
+    # Optionally mount additional config or certificates.
+    # extraVolumeMounts:
+    # - mountPath: "/config/cacerts"
+    #   name: cacert-volume
+    # extraVolumes:
+    # - name: cacert-volume
+    #   secret:
+    #     defaultMode: 420
+    #     secretName: doi-cacert-secret
+
+    # Additional non-secret config files or keys merged into the DOI ConfigMap.
+    extraConfigData: {}
+
+    # Groups that can alter logging. Empty array means nobody can alter it.
+    loggingGroups: []
+
+    resources:
+      requests:
+        memory: "500Mi"
+        cpu: "500m"
+      limits:
+        memory: "1Gi"
+        cpu: "750m"
+
+  # Specify extra hostnames that will be added to the Pod's /etc/hosts file.
+  # extraHosts:
+  #   - ip: 127.3.34.5
+  #     hostname: myhost.example.org
+  # extraHosts: []
+
+tolerations: []
+
+volumeInit:
+  image: busybox:1.36
+  imagePullPolicy: IfNotPresent
+  securityContext: {}
+  podSecurityContext: {}
+
+serviceAccount:
+  create: false
+  automount: true
+  annotations: {}
+  name: ""
+
+livenessProbe:
+  httpGet:
+    path: /doi/availability
+    port: 8080
+  periodSeconds: 30
+
+readinessProbe:
+  httpGet:
+    path: /doi/availability
+    port: 8080
+  periodSeconds: 15
+
+startupProbe:
+  httpGet:
+    path: /doi/availability
+    port: 8080
+  initialDelaySeconds: 10
+  timeoutSeconds: 30
+  periodSeconds: 10
+  failureThreshold: 30

--- a/helm/applications/storage-ui/README.md
+++ b/helm/applications/storage-ui/README.md
@@ -22,7 +22,7 @@ A Helm chart to install the User Storage UI
 | deployment.storageUI.cookieSignaturePublicKey.existingSecret.path | string | `""` |  |
 | deployment.storageUI.gmsID | string | `nil` |  |
 | deployment.storageUI.identityManagerClass | string | `"org.opencadc.auth.StandardIdentityManager"` |  |
-| deployment.storageUI.image | string | `"images.opencadc.org/client/storage-ui:1.4.3"` |  |
+| deployment.storageUI.image | string | `"images.opencadc.org/client/storageui:1.4.4"` |  |
 | deployment.storageUI.imagePullPolicy | string | `"IfNotPresent"` |  |
 | deployment.storageUI.resources.limits.cpu | string | `"750m"` |  |
 | deployment.storageUI.resources.limits.memory | string | `"1Gi"` |  |

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,6 +19,13 @@
       "monorepo-tags": true,
       "extra-files": ["README.md"]
     },
+    "helm/applications/doi": {
+      "package-name": "doi",
+      "release-type": "helm",
+      "changelog-path": "CHANGELOG.md",
+      "monorepo-tags": true,
+      "extra-files": ["README.md"]
+    },
     "helm/applications/posix-mapper": {
       "package-name": "posixmapper",
       "release-type": "helm",


### PR DESCRIPTION
## Summary

Add an initial Helm chart for deploying the CADC DOI service to Kubernetes.

The chart is based on the DOI source configuration and is intended to support
migration from the existing Docker Swarm deployment. Current Swarm deployment
details still need to be reviewed before the chart is considered ready for
deployment.

## Kubernetes resources

The chart currently defines:

- Deployment
- Service
- Ingress
- ServiceAccount
- ConfigMap
- External Secret references
- Helm connectivity test

## Information required from the current deployment

- [ ] Confirm container image repository, tag, digest, and architecture
- [ ] Confirm active runtime configuration files
- [ ] Confirm certificate/credential filenames and mount paths
- [ ] Confirm which values must be managed as Kubernetes Secrets
- [ ] Confirm hostname, Ingress class, and forwarded certificate headers
- [ ] Confirm target namespace and image pull credentials
- [ ] Confirm container security context and resource requirements
- [ ] Validate the chart against the existing Docker Swarm configuration